### PR TITLE
Add auto-encryption when token is saved

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -38,9 +38,12 @@ if ( function_exists( 'add_action' ) ) {
 
 		}
 	);
+}
+
+if ( function_exists( 'add_filter' ) ) {
 
 	// Auto-encrypt token on save.
-	add_action(
+	add_filter(
 		'pre_update_option_nfd_data_token',
 		function ( $value ) {
 			$encryption = new Encryption();
@@ -53,10 +56,12 @@ if ( function_exists( 'add_action' ) ) {
 
 // Register activation hook (outside init so it will fire on activation).
 if ( function_exists( 'register_activation_hook' ) ) {
+
 	register_activation_hook(
 		container()->plugin()->basename,
 		function () {
 			Transient::set( 'nfd_plugin_activated', container()->plugin()->basename );
 		}
 	);
+
 }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,60 +1,62 @@
 <?php
 
-use NewfoldLabs\WP\ModuleLoader\Container;
 use NewfoldLabs\WP\Module\Data\Data;
+use NewfoldLabs\WP\Module\Data\Helpers\Encryption;
 use NewfoldLabs\WP\Module\Data\Helpers\Transient;
 
 use function NewfoldLabs\WP\ModuleLoader\register as registerModule;
-use function NewfoldLabs\WP\ModuleLoader\container as moduleContainer;
+use function NewfoldLabs\WP\ModuleLoader\container;
 
-// Define constants
 // Do not allow multiple copies of the module to be active
 if ( defined( 'NFD_DATA_MODULE_VERSION' ) ) {
 	exit;
-} else {
-	define( 'NFD_DATA_MODULE_VERSION', '2.0.0' );
+}
 
-	/**
-	 * Register the data module
-	 */
-	if ( function_exists( 'add_action' ) ) {
+define( 'NFD_DATA_MODULE_VERSION', '2.0.0' );
 
-		add_action(
-			'plugins_loaded',
-			function () {
+/**
+ * Register the data module
+ */
+if ( function_exists( 'add_action' ) ) {
 
-				registerModule(
-					array(
-						'name'     => 'data',
-						'label'    => __( 'Data', 'newfold-data-module' ),
-						'callback' => function ( Container $container ) {
-							$module = new Data( $container );
-							$module->start();
-						},
-						'isActive' => true,
-						'isHidden' => true,
-					)
-				);
+	add_action(
+		'plugins_loaded',
+		function () {
 
-			}
-		);
+			registerModule(
+				array(
+					'name'     => 'data',
+					'label'    => __( 'Data', 'newfold-data-module' ),
+					'callback' => function () {
+						$module = new Data();
+						$module->start();
+					},
+					'isActive' => true,
+					'isHidden' => true,
+				)
+			);
 
-	}
+		}
+	);
 
-	/**
-	 * Register activation hook (outside init so it will fire on activation).
-	 */
-	function nfd_plugin_activate() {
-		if ( function_exists( 'moduleContainer' ) ) {
+	// Auto-encrypt token on save.
+	add_action(
+		'pre_update_option_nfd_data_token',
+		function ( $value ) {
+			$encryption = new Encryption();
+
+			return $encryption->encrypt( $value );
+		}
+	);
+
+}
+
+// Register activation hook (outside init so it will fire on activation).
+if ( function_exists( 'register_activation_hook' ) ) {
+	register_activation_hook(
+		container()->plugin()->basename,
+		function () {
 			Transient::set( 'nfd_plugin_activated', container()->plugin()->basename );
 		}
-	}
-
-	if ( function_exists( 'register_activation_hook' ) && function_exists( 'moduleContainer' ) ) {
-		register_activation_hook(
-			container()->plugin()->basename,
-			'nfd_plugin_activate'
-		);
-	}
-
+	);
 }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -3,9 +3,9 @@
 use NewfoldLabs\WP\Module\Data\Data;
 use NewfoldLabs\WP\Module\Data\Helpers\Encryption;
 use NewfoldLabs\WP\Module\Data\Helpers\Transient;
+use NewfoldLabs\WP\ModuleLoader\Container;
 
 use function NewfoldLabs\WP\ModuleLoader\register as registerModule;
-use function NewfoldLabs\WP\ModuleLoader\container;
 
 // Do not allow multiple copies of the module to be active
 if ( defined( 'NFD_DATA_MODULE_VERSION' ) ) {
@@ -38,9 +38,6 @@ if ( function_exists( 'add_action' ) ) {
 
 		}
 	);
-}
-
-if ( function_exists( 'add_filter' ) ) {
 
 	// Auto-encrypt token on save.
 	add_filter(
@@ -52,15 +49,16 @@ if ( function_exists( 'add_filter' ) ) {
 		}
 	);
 
-}
-
-// Register activation hook (outside init so it will fire on activation).
-if ( function_exists( 'register_activation_hook' ) ) {
-
-	register_activation_hook(
-		container()->plugin()->basename,
-		function () {
-			Transient::set( 'nfd_plugin_activated', container()->plugin()->basename );
+	// Register activation hook
+	add_action(
+		'newfold_container_set',
+		function ( Container $container ) {
+			register_activation_hook(
+				$container->plugin()->file,
+				function () use ( $container ) {
+					Transient::set( 'nfd_plugin_activated', $container->plugin()->basename );
+				}
+			);
 		}
 	);
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -12,7 +12,7 @@ if ( defined( 'NFD_DATA_MODULE_VERSION' ) ) {
 	exit;
 }
 
-define( 'NFD_DATA_MODULE_VERSION', '2.0.0' );
+define( 'NFD_DATA_MODULE_VERSION', '2.1.0' );
 
 /**
  * Register the data module

--- a/src/HiiveConnection.php
+++ b/src/HiiveConnection.php
@@ -152,9 +152,10 @@ class HiiveConnection implements SubscriberInterface {
 		if ( 201 === $status || 200 === $status ) {
 			$body = json_decode( wp_remote_retrieve_body( $response ) );
 			if ( ! empty( $body->token ) ) {
-				$encryption      = new Encryption();
-				$encrypted_token = $encryption->encrypt( $body->token );
-				update_option( 'nfd_data_token', $encrypted_token );
+
+				// Token is auto-encrypted using the `pre_update_option_nfd_data_token` hook.
+				update_option( 'nfd_data_token', $body->token );
+
 			}
 		}
 


### PR DESCRIPTION
This PR ensures that raw tokens stored via `wp option set "token" --autoload` will be encrypted and usable for a valid connection.