### PR TITLE
Feature/verify module version on release

### DIFF
--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -11,6 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Validate version number
+        if: ${{ (github.repository == 'newfold-labs/wp-module-data') && (github.event.release.prerelease == false) }}
+        run: |
+          taggedVersion=${{ env.VERSION }}
+          moduleVersion=`grep "NFD_DATA_MODULE_VERSION" bootstrap.php | grep -Eo "[0-9\.]*"`
+          echo "Tagged version: $taggedVersion"
+          echo "Module version: $moduleVersion"
+          [[ "$taggedVersion" == "$moduleVersion" ]] || exit 1
+
       - name: Set Package
         id: package
         env:

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -13,7 +13,7 @@ if ( defined( 'NFD_DATA_MODULE_VERSION' ) ) {
 	exit;
 }
 
-define( 'NFD_DATA_MODULE_VERSION', '2.2.5' );
+define( 'NFD_DATA_MODULE_VERSION', '2.3' );
 
 /**
  * Register the data module


### PR DESCRIPTION
We have a version for this module since it's one that we may need versioning on. We tend to forget to update the version though as we release. 

I think this should help us keep them in sync. Though not too sure we need it since we haven't yet used it for anything, but we may have a need for it with Jarvis and the other brand plugins coming on board.