### PR TITLE
Add an API that can handle an array of events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 debug.log
+.DS_Store

--- a/src/API/Events.php
+++ b/src/API/Events.php
@@ -84,7 +84,7 @@ class Events extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'create_item' ),
-					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					// 'permission_callback' => array( $this, 'create_item_permissions_check' ),
 				),
 			)
 		);
@@ -96,7 +96,7 @@ class Events extends WP_REST_Controller {
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'create_items' ),
-					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					// 'permission_callback' => array( $this, 'create_item_permissions_check' ),
 				),
 			)
 		);
@@ -187,7 +187,7 @@ class Events extends WP_REST_Controller {
 		$events = $request->get_json_params();
 		if ( ! rest_is_array( $events ) ) {
 			return new \WP_Error(
-				'rest_cannot_log_event',
+				'rest_cannot_log_events',
 				__( 'Request does not contain an array of events.' )
 			);
 		}
@@ -213,7 +213,7 @@ class Events extends WP_REST_Controller {
 
 		if ( ! empty( $errors ) ) {
 			return new \WP_Error(
-				'rest_cannot_log_event',
+				'rest_cannot_log_events',
 				__( 'Some events failed.' ),
 				array(
 					'errors' => $errors,

--- a/src/API/Events.php
+++ b/src/API/Events.php
@@ -84,7 +84,7 @@ class Events extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'create_item' ),
-					// 'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
 				),
 			)
 		);
@@ -96,7 +96,7 @@ class Events extends WP_REST_Controller {
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'create_items' ),
-					// 'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
 				),
 			)
 		);


### PR DESCRIPTION
The [ js-utility-ui-analytics package](https://github.com/newfold-labs/js-utility-ui-analytics) provides an option to queue events happening in an application and send an array of events to the API via debounce/manual dispatch. Currently, a batch API exists only in Onboarding https://github.com/newfold-labs/wp-module-onboarding/blob/9dbee160a2c3ac60b512be6b01872024e26be427/includes/RestApi/EventsController.php#L46. 

As more modules start using the option to queue an event instead of placing a network call every time, we will need the API to exist in a shared, always activated module. This PR implements a version of the API in Onboarding to serve that purpose.