### PR TITLE
Add tracking for WooCommerce payment methods

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -19,7 +19,7 @@ if ( defined( 'NFD_DATA_MODULE_VERSION' ) ) {
 	exit;
 }
 
-define( 'NFD_DATA_MODULE_VERSION', '2.4.0' );
+define( 'NFD_DATA_MODULE_VERSION', '2.4.1' );
 
 if ( function_exists( 'is_admin' ) && is_admin() ) {
 	$upgrade_handler = new UpgradeHandler(

--- a/src/Listeners/Commerce.php
+++ b/src/Listeners/Commerce.php
@@ -35,7 +35,7 @@ class Commerce extends Listener {
 			'payment_method_title' => $order->get_payment_method_title(),
 		);
 
-		$this->push( 'woocommerce_order_processing', $data );
+		$this->push( 'woocommerce_order_status_processing', $data );
 
 	}
 

--- a/src/Listeners/Commerce.php
+++ b/src/Listeners/Commerce.php
@@ -13,14 +13,38 @@ class Commerce extends Listener {
 	 * @return void
 	 */
 	public function register_hooks() {
+		add_action( 'woocommerce_order_status_processing', array( $this, 'on_payment' ), 10, 2 );
 		add_filter( 'newfold_wp_data_module_cron_data_filter', array( $this, 'products_count' ) );
 		add_filter( 'newfold_wp_data_module_cron_data_filter', array( $this, 'orders_count' ) );
 	}
 
 	/**
+	 * On Payment, send data to Hiive
+	 *
+	 * @param  int  $order_id
+	 * @param  \WC_Order  $order
+	 *
+	 * @return void
+	 */
+	public function on_payment( $order_id, \WC_Order $order ) {
+
+		$data = array(
+			'order_currency'       => $order->get_currency(),
+			'order_total'          => $order->get_total(),
+			'payment_method'       => $order->get_payment_method(),
+			'payment_method_title' => $order->get_payment_method_title(),
+		);
+
+		error_log( wp_json_encode( $data ) );
+
+		$this->push( 'woocommerce_payment_method', $data );
+
+	}
+
+	/**
 	 * Products Count
 	 *
-	 * @param string $data Array of data to be sent to hiive
+	 * @param  string  $data  Array of data to be sent to Hiive
 	 *
 	 * @return string Array of data
 	 */
@@ -36,7 +60,7 @@ class Commerce extends Listener {
 	/**
 	 * Orders Count
 	 *
-	 * @param string $data Array of data to be sent to hiive
+	 * @param  string  $data  Array of data to be sent to Hiive
 	 *
 	 * @return string Array of data
 	 */

--- a/src/Listeners/Commerce.php
+++ b/src/Listeners/Commerce.php
@@ -35,9 +35,7 @@ class Commerce extends Listener {
 			'payment_method_title' => $order->get_payment_method_title(),
 		);
 
-		error_log( wp_json_encode( $data ) );
-
-		$this->push( 'woocommerce_payment_method', $data );
+		$this->push( 'woocommerce_order_processing', $data );
 
 	}
 

--- a/src/Listeners/Content.php
+++ b/src/Listeners/Content.php
@@ -26,8 +26,8 @@ class Content extends Listener {
 	 * Post status transition
 	 *
 	 * @param string  $new_status The new post status
-	 * @param string  $old_status The new post status
-	 * @param WP_Post $post       Post object
+	 * @param string  $old_status The old post status
+	 * @param \WP_Post $post       Post object
 	 * @return void
 	 */
 	public function post_status( $new_status, $old_status, $post ) {


### PR DESCRIPTION
This PR adds tracking around WooCommerce payment methods.  

Here is an example payload:

![Request_Details_-_Telescope](https://github.com/newfold-labs/wp-module-data/assets/890951/4384c4da-020d-4947-bba8-4fc0e60e39f9)
