### PR TITLE
Shorten capability transient

### DIFF
--- a/src/SiteCapabilities.php
+++ b/src/SiteCapabilities.php
@@ -20,7 +20,7 @@ class SiteCapabilities {
 		$capabilities = get_transient( 'nfd_site_capabilities' );
 		if ( false === $capabilities ) {
 			$capabilities = $this->fetch();
-			set_transient( 'nfd_site_capabilities', $capabilities, 30 * DAY_IN_SECONDS );
+			set_transient( 'nfd_site_capabilities', $capabilities, 4 * HOUR_IN_SECONDS );
 		}
 
 		return $capabilities;

--- a/upgrades/2.4.2.php
+++ b/upgrades/2.4.2.php
@@ -1,0 +1,3 @@
+<?php
+
+delete_transient( 'nfd_site_capabilities' );


### PR DESCRIPTION
The capability transient is currently set with a TTL of 30 days. This PR shortens it to 4 hours to enable faster feature release rollouts. I've also added an upgrade routine to clear the old 30 day expiration value immediately. 