### PR TITLE
Fix issue with double decryption of data tokens

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -67,15 +67,13 @@ if ( function_exists( 'add_action' ) && function_exists( 'add_filter' ) ) {
 		}
 	);
 
-	// Auto-decrypt token when fetched via WP-CLI
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
-		add_filter(
-			'option_nfd_data_token',
-			function ( $value ) {
-				return ( new Encryption() )->decrypt( $value );
-			}
-		);
-	}
+	// Auto-decrypt token when fetched
+	add_filter(
+		'option_nfd_data_token',
+		function ( $value ) {
+			return ( new Encryption() )->decrypt( $value );
+		}
+	);
 
 	// Register activation/deactivation hooks
 	add_action(

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -19,7 +19,7 @@ if ( defined( 'NFD_DATA_MODULE_VERSION' ) ) {
 	exit;
 }
 
-define( 'NFD_DATA_MODULE_VERSION', '2.4.2' );
+define( 'NFD_DATA_MODULE_VERSION', '2.4.3' );
 
 if ( function_exists( 'is_admin' ) && is_admin() ) {
 	$upgrade_handler = new UpgradeHandler(

--- a/src/HiiveConnection.php
+++ b/src/HiiveConnection.php
@@ -249,17 +249,10 @@ class HiiveConnection implements SubscriberInterface {
 	/**
 	 * Try to return the auth token
 	 *
-	 * @return string|null The decrypted token if it's set
+	 * @return string|false The decrypted token if it's set
 	 */
 	public static function get_auth_token() {
-		$encrypted_token = get_option( 'nfd_data_token' );
-		if ( false !== $encrypted_token ) {
-			$encryption = new Encryption();
-
-			return $encryption->decrypt( $encrypted_token );
-		}
-
-		return null;
+		return get_option( 'nfd_data_token' );
 	}
 
 


### PR DESCRIPTION
We were accidentally decrypting the token twice on wp-cli calls. This led to tokens being invalidated and refreshed more frequently than required. 

This simply forces the decryption to happen every time so that we aren't manually decrypting at other times. 