### PR TITLE
PRESS4-370 | Ecomdash Event is not being passed to Tableau properly

### DIFF
--- a/includes/Listeners/Commerce.php
+++ b/includes/Listeners/Commerce.php
@@ -266,10 +266,6 @@ class Commerce extends Listener {
             $localVar = (int)$localVar+1;
             setcookie("ecomdash_counter",$localVar);
             if($localVar==1){
-            $WC_Product = 'hellow';
-                echo '<script type="text/javascript">
-                    console.log("inside the logic");
-        		</script>';
             $url =  is_ssl() ? "https://" : "http://";
             $url .= $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
             $data = array(

--- a/includes/Listeners/Commerce.php
+++ b/includes/Listeners/Commerce.php
@@ -24,6 +24,7 @@ class Commerce extends Listener {
 		add_filter( 'pre_update_option_nfd_ecommerce_captive_flow_stripe', array( $this, 'stripe_connection' ), 10, 2 );
 		// Paypal Connection
 		add_filter( 'pre_update_option_yith_ppwc_merchant_data_production', array( $this, 'paypal_connection' ), 10, 2 );
+		add_filter('toplevel_page_newfold-ecomdash', array($this, 'ecomdash_connected'));
 	}
 
 	/**
@@ -249,4 +250,35 @@ class Commerce extends Listener {
 
 		return $new_option;
 	}
+	
+	/**
+	 * Ecomdash connection, send data to Hiive
+	 *
+	 * @return void
+	 */
+	public function ecomdash_connected() {
+        $isecomdash_connected = \get_option( 'ewc4wp_sso_account_status', '' );
+        $localVar = $_COOKIE["ecomdash_counter"];
+        if($isecomdash_connected === 'disconnected' || !isset($localVar)){
+            setcookie("ecomdash_counter", 0);
+        }
+        if($isecomdash_connected === 'connected'){
+            $localVar = (int)$localVar+1;
+            setcookie("ecomdash_counter",$localVar);
+            if($localVar==1){
+            $WC_Product = 'hellow';
+                echo '<script type="text/javascript">
+                    console.log("inside the logic");
+        		</script>';
+            $url =  is_ssl() ? "https://" : "http://";
+            $url .= $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+            $data = array(
+                "url"       => $url
+            );
+            $this->push(
+			  "ecomdash_connected",
+                $data
+            );}
+        }
+    }
 }

--- a/includes/Listeners/Commerce.php
+++ b/includes/Listeners/Commerce.php
@@ -260,11 +260,11 @@ class Commerce extends Listener {
         $isecomdash_connected = \get_option( 'ewc4wp_sso_account_status', '' );
         $localVar = $_COOKIE["ecomdash_counter"];
         if($isecomdash_connected === 'disconnected' || !isset($localVar)){
-            setcookie("ecomdash_counter", 0);
+            setcookie("ecomdash_counter", 0, time() + (365 * 24 * 60 * 60));
         }
         if($isecomdash_connected === 'connected'){
             $localVar = (int)$localVar+1;
-            setcookie("ecomdash_counter",$localVar);
+            setcookie("ecomdash_counter",$localVar, time() + (365 * 24 * 60 * 60));
             if($localVar==1){
             $url =  is_ssl() ? "https://" : "http://";
             $url .= $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];

--- a/includes/Listeners/Commerce.php
+++ b/includes/Listeners/Commerce.php
@@ -24,7 +24,7 @@ class Commerce extends Listener {
 		add_filter( 'pre_update_option_nfd_ecommerce_captive_flow_stripe', array( $this, 'stripe_connection' ), 10, 2 );
 		// Paypal Connection
 		add_filter( 'pre_update_option_yith_ppwc_merchant_data_production', array( $this, 'paypal_connection' ), 10, 2 );
-		add_filter('toplevel_page_newfold-ecomdash', array($this, 'ecomdash_connected'));
+		add_filter('update_option_ewc4wp_sso_account_status', array($this, 'ecomdash_connected'));
 	}
 
 	/**
@@ -254,29 +254,23 @@ class Commerce extends Listener {
 	/**
 	 * Ecomdash connection, send data to Hiive
 	 *
-	 * @return void
+	 * @param string $new_option New value of the update_option_ewc4wp_sso_account_status option
+	 * @param string $old_option Old value of the update_option_ewc4wp_sso_account_status option
+	 *
+	 * @return string The new option value
 	 */
-	public function ecomdash_connected() {
-        $isecomdash_connected = \get_option( 'ewc4wp_sso_account_status', '' );
-        $ecomdash_counter = isset($_COOKIE["ecomdash_counter"]) ? $_COOKIE["ecomdash_counter"] : 0;
-		$ecomdash_counter = filter_var($ecomdash_counter, FILTER_SANITIZE_NUMBER_INT);
-        if($isecomdash_connected === 'disconnected'){
-            setcookie("ecomdash_counter", 0, time() + (365 * 24 * 60 * 60));
-        }
-        if($isecomdash_connected === 'connected'){
-            $ecomdash_counter = $ecomdash_counter+1;
-            setcookie("ecomdash_counter",$ecomdash_counter, time() + (365 * 24 * 60 * 60));
-            if($ecomdash_counter === 1){
-				$url =  is_ssl() ? "https://" : "http://";
-				$url .= $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-				$data = array(
-					"url"	=> $url
-				);
-				$this->push(
-					"ecomdash_connected",
-					$data
-				);
-			}
-        }
-    }
+	public function ecomdash_connected($new_option, $old_option) {
+		if ( $new_option !== $old_option && ! empty( $new_option ) && $new_option === 'connected' ) {
+			$url =  is_ssl() ? "https://" : "http://";
+			$url .= $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+			$data = array(
+				"url"	=> $url
+			);
+			$this->push(
+				"ecomdash_connected",
+				$data
+			);
+    	}
+		return $new_option;
+	}
 }

--- a/includes/Listeners/Commerce.php
+++ b/includes/Listeners/Commerce.php
@@ -258,23 +258,25 @@ class Commerce extends Listener {
 	 */
 	public function ecomdash_connected() {
         $isecomdash_connected = \get_option( 'ewc4wp_sso_account_status', '' );
-        $localVar = $_COOKIE["ecomdash_counter"];
-        if($isecomdash_connected === 'disconnected' || !isset($localVar)){
+        $ecomdash_counter = isset($_COOKIE["ecomdash_counter"]) ? $_COOKIE["ecomdash_counter"] : 0;
+		$ecomdash_counter = filter_var($ecomdash_counter, FILTER_SANITIZE_NUMBER_INT);
+        if($isecomdash_connected === 'disconnected'){
             setcookie("ecomdash_counter", 0, time() + (365 * 24 * 60 * 60));
         }
         if($isecomdash_connected === 'connected'){
-            $localVar = (int)$localVar+1;
-            setcookie("ecomdash_counter",$localVar, time() + (365 * 24 * 60 * 60));
-            if($localVar==1){
-            $url =  is_ssl() ? "https://" : "http://";
-            $url .= $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-            $data = array(
-                "url"       => $url
-            );
-            $this->push(
-			  "ecomdash_connected",
-                $data
-            );}
+            $ecomdash_counter = $ecomdash_counter+1;
+            setcookie("ecomdash_counter",$ecomdash_counter, time() + (365 * 24 * 60 * 60));
+            if($ecomdash_counter === 1){
+				$url =  is_ssl() ? "https://" : "http://";
+				$url .= $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+				$data = array(
+					"url"	=> $url
+				);
+				$this->push(
+					"ecomdash_connected",
+					$data
+				);
+			}
         }
     }
 }


### PR DESCRIPTION
JIRA ticket:- https://jira.newfold.com/browse/PRESS4-370

- We have to triggered the event to send the data to hive only when we connect to Ecomdash for the first time. 
- Since we are not able to find the hook for triggering the event when the Ecomdash is connected.
- As an alternate approach we are using the cookies to avoid sending the data to hive on every page load/refresh.

## Code changes
- We are fetching the value of ``isecomdash_connected`` from DB key ``ewc4wp_sso_account_status``
- if ``isecomdash_connected`` is **disconnected** then we are setting cookie value of ``ecomdash_counter`` as **0**
- if ``isecomdash_connected`` is **connected** then we are increasing the cookie value of ``ecomdash_counter`` with **+1**

- When ``ecomdash_counter === 1`` then only we are going to send the data to hive.
- The remaining values (other than 1) the condition won't satisfy since the data won't sent to hive.


**Note:- Please let us know if there is any better approach for this. we will definitely try to work on it.**