### PR TITLE
Update/use container to get brand value

### DIFF
--- a/includes/HiiveConnection.php
+++ b/includes/HiiveConnection.php
@@ -263,18 +263,19 @@ class HiiveConnection implements SubscriberInterface {
 	 */
 	public function get_core_data() {
 		global $wpdb, $wp_version;
+		$container = container();
 
 		$data = array(
-			'brand'       => sanitize_title( get_option( 'mm_brand', 'false' ) ),
+			'brand'       => $container->plugin()->brand,
 			'cache_level' => intval( get_option( 'newfold_cache_level', 2 ) ),
-			'cloudflare'  => get_option( 'newfold_cloudflare_enabled', false ),
+			'cloudflare'   => get_option( 'newfold_cloudflare_enabled', false ),
 			'data'        => NFD_DATA_MODULE_VERSION,
 			'email'       => get_option( 'admin_email' ),
 			'hostname'    => gethostname(),
 			'mysql'       => $wpdb->db_version(),
-			'origin'      => container()->plugin()->get( 'id', 'error' ),
+			'origin'      => $container->plugin()->get( 'id', 'error' ),
 			'php'         => phpversion(),
-			'plugin'      => container()->plugin()->get( 'version', '0' ),
+			'plugin'      => $container->plugin()->get( 'version', '0' ),
 			'url'         => get_site_url(),
 			'username'    => get_current_user(),
 			'wp'          => $wp_version,

--- a/includes/HiiveConnection.php
+++ b/includes/HiiveConnection.php
@@ -266,7 +266,7 @@ class HiiveConnection implements SubscriberInterface {
 		$container = container();
 
 		$data = array(
-			'brand'       => $container->plugin()->brand,
+			'brand'       => sanitize_title( $container->plugin()->brand ),
 			'cache_level' => intval( get_option( 'newfold_cache_level', 2 ) ),
 			'cloudflare'   => get_option( 'newfold_cloudflare_enabled', false ),
 			'data'        => NFD_DATA_MODULE_VERSION,


### PR DESCRIPTION
Use the container to get brand value sent to hiive. 

The value is placed in the container at the plugin level in the bootstrap file using the Plugin service in each brand plugin. It is pulling from `mm_brand` and setting the default to match the brand plugin id if there is no `mm_brand`.

Addresses: [PRESS1-207](https://jira.newfold.com/browse/PRESS1-207)