### PR TITLE
Fix issue where error response is stored as site capabilities array

### DIFF
--- a/includes/SiteCapabilities.php
+++ b/includes/SiteCapabilities.php
@@ -29,7 +29,7 @@ class SiteCapabilities {
 	/**
 	 * Check if a capability exists.
 	 *
-	 * @param  string $capability Capability name.
+	 * @param string $capability Capability name.
 	 *
 	 * @return bool
 	 */
@@ -40,7 +40,7 @@ class SiteCapabilities {
 	/**
 	 * Get the value of a capability.
 	 *
-	 * @param  string $capability Capability name.
+	 * @param string $capability Capability name.
 	 *
 	 * @return bool
 	 */
@@ -67,7 +67,7 @@ class SiteCapabilities {
 			)
 		);
 
-		if ( ! is_wp_error( $response ) ) {
+		if ( wp_remote_retrieve_response_code( $response ) === 200 && ! is_wp_error( $response ) ) {
 			$body = wp_remote_retrieve_body( $response );
 			$data = json_decode( $body, true );
 			if ( $data && is_array( $data ) ) {


### PR DESCRIPTION
Fix the issue where error responses were stored as the capabilities array—now checks for 200 status.

Prevents issues like:
![Cursor_and_Teams_and_Channels___General___Microsoft_Teams](https://github.com/newfold-labs/wp-module-data/assets/890951/bf4e9e09-79af-40f7-b68b-081de9922c4e)
