### PR TITLE
Listen for the `newfold/coming-soon/disabled` action, not changes to `mm_coming_soon`

### DIFF
--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Validate version number
         if: ${{ (github.repository == 'newfold-labs/wp-module-data') && (github.event.release.prerelease == false) }}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -19,7 +19,7 @@ if ( defined( 'NFD_DATA_MODULE_VERSION' ) ) {
 	return;
 }
 
-define( 'NFD_DATA_MODULE_VERSION', '2.4.17' );
+define( 'NFD_DATA_MODULE_VERSION', '2.4.18' );
 
 if ( function_exists( 'is_admin' ) && is_admin() ) {
 	$upgrade_handler = new UpgradeHandler(

--- a/includes/Listeners/BluehostPlugin.php
+++ b/includes/Listeners/BluehostPlugin.php
@@ -13,8 +13,9 @@ class BluehostPlugin extends Listener {
 	 * @return void
 	 */
 	public function register_hooks() {
+
 		// Site Launched - Coming Soon page disabled
-		add_filter( 'pre_update_option_mm_coming_soon', array( $this, 'site_launch' ), 10, 2 );
+		add_action( 'newfold/coming-soon/disabled', array( $this, 'site_launch' ) );
 
 		// SSO (Legacy)
 		add_action( 'eig_sso_success', array( $this, 'sso_success' ), 10, 2 );
@@ -30,25 +31,17 @@ class BluehostPlugin extends Listener {
 
 	/**
 	 * Disable Coming Soon
-	 *
-	 * @param string $new_option New value of the mm_coming_soon option
-	 * @param string $old_option Old value of the mm_coming_soon option
-	 *
-	 * @return string The new option value
 	 */
-	public function site_launch( $new_option, $old_option ) {
-		// Ensure it only fires when Coming Soon is disabled
-		if ( $new_option !== $old_option && false === wp_validate_boolean( $new_option ) ) {
-			$mm_install_time = get_option( 'mm_install_date', gmdate( 'M d, Y' ) );
-			$install_time    = apply_filters( 'nfd_install_date_filter', strtotime( $mm_install_time ) );
+	public function site_launch() {
+		$mm_install_time = get_option( 'mm_install_date', gmdate( 'M d, Y' ) );
+		$install_time    = apply_filters( 'nfd_install_date_filter', strtotime( $mm_install_time ) );
 
-			$data = array(
+		$this->push(
+			'site_launched',
+			array(
 				'ttl' => time() - $install_time,
-			);
-			$this->push( 'site_launched', $data );
-		}
-
-		return $new_option;
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
When trying to detect when the Coming Soon feature has been disabled, use the new `newfold/coming-soon/disabled` hook instead of listening to changes in the `mm_coming_soon` value. 