### PR TITLE
Press0-546 | Make login events only fire for admins

### DIFF
--- a/includes/Listeners/Admin.php
+++ b/includes/Listeners/Admin.php
@@ -18,7 +18,7 @@ class Admin extends Listener {
 		add_action( 'customize_controls_print_footer_scripts', array( $this, 'view' ) );
 
 		// Login
-		add_action( 'wp_login', array( $this, 'login' ) );
+		add_action( 'wp_login', array( $this, 'login' ), 10, 2 );
 
 		// Logout
 		add_action( 'wp_logout', array( $this, 'logout' ) );
@@ -50,8 +50,10 @@ class Admin extends Listener {
 	 *
 	 * @return void
 	 */
-	public function login() {
-		$this->push( 'login' );
+	public function login( $user_login, $user ) {
+		if( ( $user_login == "admin" ) || ( $user->get_role_caps() && $user->get_role_caps()["manage_options"] ) ){
+			$this->push( 'login' );
+		}
 	}
 
 	/**

--- a/includes/Listeners/Admin.php
+++ b/includes/Listeners/Admin.php
@@ -47,16 +47,16 @@ class Admin extends Listener {
 
 	/**
 	 * Login
-	 * 
-	 * @param String  $user_login username
-	 * 
-	 * @param WP_User  $user logged in user info
-	 * 
+	 *
+	 * @param String $user_login username
+	 *
+	 * @param WP_User $user logged in user info
+	 *
 	 * @return void
 	 */
 	public function login( $user_login, $user ) {
-		$is_admin = array_key_exists( "administrator", $user->get_role_caps() );
-		if( ( $is_admin && $user->get_role_caps()["administrator"]) || ( $user->get_role_caps() && $user->get_role_caps()["manage_options"] ) ) {
+		$is_admin = array_key_exists( 'administrator', $user->get_role_caps() );
+		if ( ( $is_admin && $user->get_role_caps()['administrator']) || ( $user->get_role_caps() && $user->get_role_caps()['manage_options'] ) ) {
 			$this->push( 'login' );
 		}
 	}
@@ -69,5 +69,4 @@ class Admin extends Listener {
 	public function logout() {
 		$this->push( 'logout' );
 	}
-
 }

--- a/includes/Listeners/Admin.php
+++ b/includes/Listeners/Admin.php
@@ -48,7 +48,7 @@ class Admin extends Listener {
 	/**
 	 * Login
 	 *
-	 * @param String $user_login username
+	 * @param String  $user_login username
 	 *
 	 * @param WP_User $user logged in user info
 	 *
@@ -56,7 +56,7 @@ class Admin extends Listener {
 	 */
 	public function login( $user_login, $user ) {
 		$is_admin = array_key_exists( 'administrator', $user->get_role_caps() );
-		if ( ( $is_admin && $user->get_role_caps()['administrator']) || ( $user->get_role_caps() && $user->get_role_caps()['manage_options'] ) ) {
+		if ( ( $is_admin && $user->get_role_caps()['administrator'] ) || ( $user->get_role_caps() && $user->get_role_caps()['manage_options'] ) ) {
 			$this->push( 'login' );
 		}
 	}

--- a/includes/Listeners/Admin.php
+++ b/includes/Listeners/Admin.php
@@ -47,11 +47,15 @@ class Admin extends Listener {
 
 	/**
 	 * Login
-	 *
+	 * @param String $user_login username
+	 * 
+	 * @param WP_User $user logged in user info
+	 * 
 	 * @return void
 	 */
 	public function login( $user_login, $user ) {
-		if( ( $user_login == "admin" ) || ( $user->get_role_caps() && $user->get_role_caps()["manage_options"] ) ){
+		$is_admin = array_key_exists( "administrator", $user->get_role_caps() );
+		if( ( $is_admin && $user->get_role_caps()["administrator"]) || ( $user->get_role_caps() && $user->get_role_caps()["manage_options"] ) ) {
 			$this->push( 'login' );
 		}
 	}

--- a/includes/Listeners/Admin.php
+++ b/includes/Listeners/Admin.php
@@ -47,9 +47,10 @@ class Admin extends Listener {
 
 	/**
 	 * Login
-	 * @param String $user_login username
 	 * 
-	 * @param WP_User $user logged in user info
+	 * @param String  $user_login username
+	 * 
+	 * @param WP_User  $user logged in user info
 	 * 
 	 * @return void
 	 */


### PR DESCRIPTION
Jira Link
https://jira.newfold.com/browse/PRESS0-546

##
**Description**
login events only fire for admin users (or users who can manage options) and not other users

##
**Changes Done**
Checking if the logged in user is `admin` and `manage_options` is true.