### PR TITLE
Fix renamed function in helpers library 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
   },
   "require": {
     "newfold-labs/wp-module-loader": "^1.0",
+    "wp-forge/helpers": "^2.0",
     "wp-forge/wp-query-builder": "^1.0",
     "wp-forge/wp-upgrade-handler": "^1.0",
     "wpscholar/url": "^1.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,104 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f248eda5612deab791ab1f8c891ea3f5",
+    "content-hash": "31502efef0bb51e978bafa8b00739bbb",
     "packages": [
+        {
+            "name": "doctrine/inflector",
+            "version": "1.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "4bd5c1cdfcd00e9e2d8c484f79150f67e5d355d9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/4bd5c1cdfcd00e9e2d8c484f79150f67e5d355d9",
+                "reference": "4bd5c1cdfcd00e9e2d8c484f79150f67e5d355d9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^8.0",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Inflector\\": "lib/Doctrine/Inflector",
+                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Inflector is a small library that can perform string manipulations with regard to upper/lowercase and singular/plural forms of words.",
+            "homepage": "https://www.doctrine-project.org/projects/inflector.html",
+            "keywords": [
+                "inflection",
+                "inflector",
+                "lowercase",
+                "manipulation",
+                "php",
+                "plural",
+                "singular",
+                "strings",
+                "uppercase",
+                "words"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/inflector/issues",
+                "source": "https://github.com/doctrine/inflector/tree/1.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finflector",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-16T17:34:40+00:00"
+        },
         {
             "name": "newfold-labs/container",
             "version": "1.2.2",
@@ -163,6 +259,50 @@
                 "source": "https://github.com/wp-forge/fluent/tree/1.0.1"
             },
             "time": "2022-08-26T17:38:37+00:00"
+        },
+        {
+            "name": "wp-forge/helpers",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-forge/helpers.git",
+                "reference": "28ebc09a3390dbff427270a4ed2b93395e8b9b78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-forge/helpers/zipball/28ebc09a3390dbff427270a4ed2b93395e8b9b78",
+                "reference": "28ebc09a3390dbff427270a4ed2b93395e8b9b78",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "^1.3",
+                "ext-mbstring": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "includes/functions.php"
+                ],
+                "psr-4": {
+                    "WP_Forge\\Helpers\\": "includes"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Micah Wood",
+                    "email": "micah@wpscholar.com"
+                }
+            ],
+            "description": "A collection of helpers for WordPress and PHP development.",
+            "support": {
+                "issues": "https://github.com/wp-forge/helpers/issues",
+                "source": "https://github.com/wp-forge/helpers/tree/2.0"
+            },
+            "time": "2022-01-06T13:10:47+00:00"
         },
         {
             "name": "wp-forge/wp-options",

--- a/includes/Data.php
+++ b/includes/Data.php
@@ -3,6 +3,7 @@
 namespace NewfoldLabs\WP\Module\Data;
 
 use wpscholar\Url;
+use function WP_Forge\Helpers\dataGet;
 
 /**
  * Main class for the data plugin module
@@ -128,7 +129,7 @@ class Data {
 			'method'    => $_SERVER['REQUEST_METHOD'],
 			'url'       => Url::getCurrentUrl(),
 			'body'      => file_get_contents( 'php://input' ),
-			'timestamp' => data_get( getallheaders(), 'X-Timestamp' ),
+			'timestamp' => dataGet( getallheaders(), 'X-Timestamp' ),
 		);
 
 		$hash = hash( 'sha256', wp_json_encode( $data ) );


### PR DESCRIPTION
## Proposed changes

`"wp-forge/helpers": "^2.0"` is being used and had [a breaking change](https://github.com/wp-forge/helpers/releases/tag/2.0) where it namespaced and renamed a function. This PR updates this library's code to call the correct function.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

## Further comments

`wp-forge/helpers` wasn't previously required in this project's `composer.json` so I added it to keep the dependency tree clear.

Fixes #61 