### PR TITLE
Add a listener to track `wp_mail` events

### DIFF
--- a/includes/EventManager.php
+++ b/includes/EventManager.php
@@ -98,10 +98,9 @@ class EventManager {
 	 * @return array
 	 */
 	public function add_minutely_schedule( $schedules ) {
-		if ( ! array_key_exists(
-			'minutely',
-			$schedules
-		) || MINUTE_IN_SECONDS !== $schedules['minutely']['interval'] ) {
+		if ( ! array_key_exists( 'minutely', $schedules ) ||
+			MINUTE_IN_SECONDS !== $schedules['minutely']['interval']
+			) {
 			$schedules['minutely'] = array(
 				'interval' => MINUTE_IN_SECONDS,
 				'display'  => __( 'Once Every Minute' ),

--- a/includes/EventManager.php
+++ b/includes/EventManager.php
@@ -26,6 +26,7 @@ class EventManager {
 		'\\NewfoldLabs\\WP\\Module\\Data\\Listeners\\Commerce',
 		'\\NewfoldLabs\\WP\\Module\\Data\\Listeners\\Yoast',
 		'\\NewfoldLabs\\WP\\Module\\Data\\Listeners\\WonderCart',
+		'\\NewfoldLabs\\WP\\Module\\Data\\Listeners\\WPMail',
 	);
 
 	/**
@@ -92,13 +93,15 @@ class EventManager {
 	/**
 	 * Add the weekly option to cron schedules if it doesn't exist
 	 *
-	 * @param  array  $schedules  List of cron schedule options
+	 * @param  array $schedules  List of cron schedule options
 	 *
 	 * @return array
 	 */
 	public function add_minutely_schedule( $schedules ) {
-		if ( ! array_key_exists( 'minutely',
-				$schedules ) || MINUTE_IN_SECONDS !== $schedules['minutely']['interval'] ) {
+		if ( ! array_key_exists(
+			'minutely',
+			$schedules
+		) || MINUTE_IN_SECONDS !== $schedules['minutely']['interval'] ) {
 			$schedules['minutely'] = array(
 				'interval' => MINUTE_IN_SECONDS,
 				'display'  => __( 'Once Every Minute' ),
@@ -138,7 +141,7 @@ class EventManager {
 	/**
 	 * Register a new event subscriber
 	 *
-	 * @param  SubscriberInterface  $subscriber  Class subscribing to event updates
+	 * @param  SubscriberInterface $subscriber  Class subscribing to event updates
 	 *
 	 * @return void
 	 */
@@ -183,7 +186,7 @@ class EventManager {
 	/**
 	 * Push event data onto the queue
 	 *
-	 * @param  Event  $event  Details about the action taken
+	 * @param  Event $event  Details about the action taken
 	 *
 	 * @return void
 	 */
@@ -195,7 +198,7 @@ class EventManager {
 	/**
 	 * Send queued events to all subscribers
 	 *
-	 * @param  array  $events  A list of events
+	 * @param  array $events  A list of events
 	 *
 	 * @return void
 	 */

--- a/includes/Listeners/WPMail.php
+++ b/includes/Listeners/WPMail.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace NewfoldLabs\WP\Module\Data\Listeners;
+
+/**
+ * Monitors wp_mail events.
+ */
+class WPMail extends Listener {
+
+	/**
+	 * Register wp_mail_* hooks for the subscriber.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_action( 'wp_mail_succeeded', array( $this, 'mail_succeeded' ), 10, 1 );
+	}
+
+	/**
+	 * Mail sent successfully.
+	 *
+	 * @param array $mail_data An array containing the email recipient(s), subject, message, headers, and attachments.
+	 * @return void
+	 */
+	public function mail_succeeded( $mail_data ) {
+		$this->push(
+			'wp_mail',
+			array(
+				'label_key' => 'subject',
+				'subject'   => $mail_data['subject'],
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

1. Adds a new listener to track `wp_mail` events.
2. Tracks whenever an email is sent successfully using the `wp_mail_succeeded` hook.