### PR TITLE
Fix/PRESS0-1147 500 error on duplicate site name – reconnect site

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 120
+quote_type = single
+
+[*.php]
+indent_size = 4
+
+[*.json]
+indent_style = space
+indent_size = 4
+
+[composer.json]
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 debug.log
 .DS_Store
+/wordpress

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
   },
   "config": {
     "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "johnpbloch/wordpress-core-installer": true
     },
     "optimize-autoloader": true,
     "platform": {
@@ -57,6 +58,7 @@
   },
   "require-dev": {
     "10up/wp_mock": "^0.4.2",
-    "newfold-labs/wp-php-standards": "^1.2"
+    "newfold-labs/wp-php-standards": "^1.2",
+    "johnpbloch/wordpress": "*"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "31502efef0bb51e978bafa8b00739bbb",
+    "content-hash": "5a2938899238f1e48eafd2e303bc67ee",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -756,6 +756,154 @@
             "time": "2020-07-09T08:09:16+00:00"
         },
         {
+            "name": "johnpbloch/wordpress",
+            "version": "6.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/johnpbloch/wordpress.git",
+                "reference": "52bffda9c0fc4dfd3c5f6e17f71ddce4fbad6038"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/52bffda9c0fc4dfd3c5f6e17f71ddce4fbad6038",
+                "reference": "52bffda9c0fc4dfd3c5f6e17f71ddce4fbad6038",
+                "shasum": ""
+            },
+            "require": {
+                "johnpbloch/wordpress-core": "6.5.2",
+                "johnpbloch/wordpress-core-installer": "^1.0 || ^2.0",
+                "php": ">=7.0.0"
+            },
+            "type": "package",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "WordPress Community",
+                    "homepage": "https://wordpress.org/about/"
+                }
+            ],
+            "description": "WordPress is open source software you can use to create a beautiful website, blog, or app.",
+            "homepage": "https://wordpress.org/",
+            "keywords": [
+                "blog",
+                "cms",
+                "wordpress"
+            ],
+            "support": {
+                "docs": "https://developer.wordpress.org/",
+                "forum": "https://wordpress.org/support/",
+                "irc": "irc://irc.freenode.net/wordpress",
+                "issues": "https://core.trac.wordpress.org/",
+                "source": "https://core.trac.wordpress.org/browser"
+            },
+            "time": "2024-04-09T21:21:01+00:00"
+        },
+        {
+            "name": "johnpbloch/wordpress-core",
+            "version": "6.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/johnpbloch/wordpress-core.git",
+                "reference": "bf083fe2944a4683461d496086ec22319cd8bdf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/bf083fe2944a4683461d496086ec22319cd8bdf1",
+                "reference": "bf083fe2944a4683461d496086ec22319cd8bdf1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.0.0"
+            },
+            "provide": {
+                "wordpress/core-implementation": "6.5.2"
+            },
+            "type": "wordpress-core",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "WordPress Community",
+                    "homepage": "https://wordpress.org/about/"
+                }
+            ],
+            "description": "WordPress is open source software you can use to create a beautiful website, blog, or app.",
+            "homepage": "https://wordpress.org/",
+            "keywords": [
+                "blog",
+                "cms",
+                "wordpress"
+            ],
+            "support": {
+                "forum": "https://wordpress.org/support/",
+                "irc": "irc://irc.freenode.net/wordpress",
+                "issues": "https://core.trac.wordpress.org/",
+                "source": "https://core.trac.wordpress.org/browser",
+                "wiki": "https://codex.wordpress.org/"
+            },
+            "time": "2024-04-09T21:20:55+00:00"
+        },
+        {
+            "name": "johnpbloch/wordpress-core-installer",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/johnpbloch/wordpress-core-installer.git",
+                "reference": "237faae9a60a4a2e1d45dce1a5836ffa616de63e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core-installer/zipball/237faae9a60a4a2e1d45dce1a5836ffa616de63e",
+                "reference": "237faae9a60a4a2e1d45dce1a5836ffa616de63e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.6.0"
+            },
+            "conflict": {
+                "composer/installers": "<1.0.6"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0 || ^2.0",
+                "phpunit/phpunit": ">=5.7.27"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "johnpbloch\\Composer\\WordPressCorePlugin"
+            },
+            "autoload": {
+                "psr-0": {
+                    "johnpbloch\\Composer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "John P. Bloch",
+                    "email": "me@johnpbloch.com"
+                }
+            ],
+            "description": "A custom installer to handle deploying WordPress with composer",
+            "keywords": [
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/johnpbloch/wordpress-core-installer/issues",
+                "source": "https://github.com/johnpbloch/wordpress-core-installer/tree/master"
+            },
+            "time": "2020-04-16T21:44:57+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.3.6",
             "source": {
@@ -885,16 +1033,16 @@
         },
         {
             "name": "newfold-labs/wp-php-standards",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-php-standards.git",
-                "reference": "e97e34d7d2df0cefdcb6f3c06714aae417b26044"
+                "reference": "a486fb541e890ee87dc387eaea0644101e728464"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-php-standards/zipball/e97e34d7d2df0cefdcb6f3c06714aae417b26044",
-                "reference": "e97e34d7d2df0cefdcb6f3c06714aae417b26044",
+                "url": "https://api.github.com/repos/newfold-labs/wp-php-standards/zipball/a486fb541e890ee87dc387eaea0644101e728464",
+                "reference": "a486fb541e890ee87dc387eaea0644101e728464",
                 "shasum": ""
             },
             "require": {
@@ -915,10 +1063,10 @@
             ],
             "description": "PHP Code Sniffer Standards for Newfold WordPress projects.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-php-standards/tree/1.2.2",
+                "source": "https://github.com/newfold-labs/wp-php-standards/tree/1.2.3",
                 "issues": "https://github.com/newfold-labs/wp-php-standards/issues"
             },
-            "time": "2023-01-06T11:45:52+00:00"
+            "time": "2024-04-22T20:09:45+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2641,16 +2789,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.9.0",
+            "version": "3.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b"
+                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
-                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/aac1f6f347a5c5ac6bc98ad395007df00990f480",
+                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480",
                 "shasum": ""
             },
             "require": {
@@ -2717,7 +2865,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-02-16T15:06:51+00:00"
+            "time": "2024-04-23T20:25:34+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2967,7 +3115,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "ext-json": "*"
+    },
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"

--- a/includes/Helpers/Transient.php
+++ b/includes/Helpers/Transient.php
@@ -15,7 +15,7 @@ class Transient {
 	 * @return boolean
 	 */
 	public static function should_use_transients() {
-		require_once ABSPATH . '/wp-admin/includes/plugin.php';
+		require_once constant( 'ABSPATH' ) . '/wp-admin/includes/plugin.php';
 		return ! array_key_exists( 'object-cache.php', get_dropins() );
 	}
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -19,3 +19,5 @@ WP_Mock::activateStrictMode();
  */
 WP_Mock::setUsePatchwork(true);
 WP_Mock::bootstrap();
+
+require_once dirname( __DIR__, 2 ) . '/wordpress/wp-includes/class-wp-error.php';

--- a/tests/phpunit/includes/HiiveConnectionTest.php
+++ b/tests/phpunit/includes/HiiveConnectionTest.php
@@ -12,7 +12,19 @@ use function NewfoldLabs\WP\ModuleLoader\container;
  * @coversDefaultClass \NewfoldLabs\WP\Module\Data\HiiveConnection
  */
 class HiiveConnectionTest extends TestCase {
-    /**
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		WP_Mock::passthruFunction('__');
+
+		WP_Mock::userFunction('wp_json_encode')->andReturn(function($input) {
+			return json_encode($input);
+		});
+	}
+
+	/**
      * @covers ::get_core_data
      */
     public function test_plugin_sends_boxname_to_hiive(): void
@@ -86,4 +98,204 @@ class HiiveConnectionTest extends TestCase {
         self::assertArrayHasKey('server_path', $result);
         self::assertEquals('/path/on/server/', $result['server_path']);
     }
+
+
+	/**
+	 * @covers ::notify
+	 */
+	public function test_notify_returns_wperror_when_no_auth_token(): void {
+		$sut = new HiiveConnection();
+
+		$event = Mockery::mock(Event::class);
+
+		WP_Mock::userFunction('get_option')
+			->with('nfd_data_token')
+			->once()
+			->andReturnNull();
+
+		$result = $sut->notify(array($event));
+
+		self::assertInstanceOf(\WP_Error::class, $result);
+		self::assertEquals('This site is not connected to the hiive.', $result->get_error_message());
+	}
+
+	/**
+	 * @covers ::notify
+	 */
+	public function test_notify_success(): void {
+		$sut = Mockery::mock(HiiveConnection::class)->makePartial();
+		$sut->expects('get_core_data')->once()->andReturn(['brand' => 'etc']);
+
+		$event = Mockery::mock(Event::class);
+
+		WP_Mock::userFunction('get_option')
+			->with('nfd_data_token')
+			->twice()
+			->andReturn('valid_hiive_auth_token');
+
+		WP_Mock::userFunction('wp_remote_post')
+			->with('/sites/v1/events', \WP_Mock\Functions::type( 'array' ))
+			->once()->andReturn(
+			array(
+				'response' => array(
+					'code' => 200
+				),
+				'body' => json_encode(array('data' => array('notifications'))),
+			)
+		);
+
+		$sut->notify(array($event));
+
+		$this->assertConditionsMet();
+	}
+
+	/**
+	 * @covers ::notify
+	 * @covers ::reconnect
+	 * @covers ::connect
+	 * @see EnsureSiteUrl::verifyUrl() in Hiive.
+	 */
+	public function test_notify_bad_token(): void {
+		$sut = Mockery::mock(HiiveConnection::class)->makePartial();
+
+		$event = Mockery::mock(Event::class);
+
+		WP_Mock::userFunction('get_option')
+			->with('nfd_data_token')
+			->times(5)
+			->andReturn('valid_hiive_auth_token');
+
+		// Is called in the initial notify(), the connect(), and the second notify().
+		$sut->expects('get_core_data')->times(3)->andReturn(['brand' => 'etc']);
+
+		WP_Mock::userFunction('wp_remote_post')
+			->with('/sites/v1/events', \WP_Mock\Functions::type( 'array' ))
+			->twice()->andReturnValues(
+				array(
+					array(
+						'response' => array(
+							'code' => 403
+						),
+						'body' => json_encode(array('message' => 'Invalid token for url')),
+					),
+					array(
+						'response' => array(
+							'code' => 200
+						),
+						'body' => json_encode(array('data' => array('notifications'))),
+					)
+				)
+			);
+
+		// Calls ::rename()
+
+		// Calls ::connect()
+
+		// Calls ::is_throttled()
+		$sut->expects('is_throttled')->once()->andReturn(false);
+
+		// Calls ::throttle()
+		$sut->expects('throttle')->once()->andReturns();
+
+		WP_Mock::userFunction('wp_generate_password')
+			->once()
+			->andReturn('password');
+
+		$temp_dir = sys_get_temp_dir();
+
+		\Patchwork\redefine(
+			'constant',
+			function ( string $constant_name ) use ( $temp_dir ) {
+				switch ($constant_name) {
+					case 'MINUTE_IN_SECONDS':
+						return 60;
+					case 'ABSPATH':
+						return $temp_dir;
+					default:
+						return \Patchwork\relay(func_get_args());
+				}
+			}
+		);
+
+		// Calls Transient::set()
+
+		// Calls Transient::should_use_transients()
+		@mkdir($temp_dir . '/wp-admin/includes', 0777, true);
+		file_put_contents( $temp_dir .  '/wp-admin/includes/plugin.php', '<?php' );
+
+		WP_Mock::userFunction('get_dropins')
+			->once()
+			->andReturn(array());
+
+		WP_Mock::userFunction('set_transient')
+			->once()->andReturnTrue();
+
+		// Calls Plugin::collect_installed()
+
+		WP_Mock::userFunction('get_plugins')
+			->once()->andReturn(array());
+
+		WP_Mock::userFunction('get_mu_plugins')
+			->once()->andReturn(array());
+
+		WP_Mock::userFunction('get_option')
+			->with('nfd_data_connection_attempts', 0)
+			->once()
+			->andReturn(0);
+
+		WP_Mock::userFunction('update_option')
+			->with('nfd_data_connection_attempts', 1)
+			->once()->andReturnTrue();
+
+		WP_Mock::userFunction('wp_remote_post')
+			->with('/sites/v2/reconnect', \WP_Mock\Functions::type( 'array' ))
+			->once()->andReturn(array());
+
+		WP_Mock::userFunction('wp_remote_retrieve_response_code')
+			->with(\WP_Mock\Functions::type( 'array' ))
+			->once()->andReturn(200);
+
+		WP_Mock::userFunction('wp_remote_retrieve_body')
+			->with(\WP_Mock\Functions::type( 'array' ))
+			->once()->andReturn(json_encode(array('site' => array(), 'token' => 'hiive_auth_token')));
+
+		WP_Mock::userFunction('update_option')
+			->with('nfd_data_token', 'hiive_auth_token')
+			->once()->andReturnTrue();
+
+		$sut->notify(array($event));
+
+		$this->assertConditionsMet();
+	}
+
+	public function test_fails_to_reconnect()
+	{
+		$sut = Mockery::mock(HiiveConnection::class)->makePartial();
+		$sut->expects('get_core_data')->once()->andReturn(['brand' => 'etc']);
+
+		$event = Mockery::mock(Event::class);
+
+		WP_Mock::userFunction('get_option')
+			->with('nfd_data_token')
+			->twice()
+			->andReturn('valid_hiive_auth_token');
+
+		WP_Mock::userFunction('wp_remote_post')
+			->with('/sites/v1/events', \WP_Mock\Functions::type( 'array' ))
+			->once()->andReturn(
+				array(
+					'response' => array(
+						'code' => 403
+					),
+					'body' => json_encode(array('message' => 'Invalid token for url')),
+				)
+			);
+
+		$sut->expects('reconnect')->once()->andReturnFalse();
+
+		$result = $sut->notify(array($event));
+
+		self::assertInstanceOf(\WP_Error::class, $result);
+		self::assertEquals('This site is not connected to the hiive.', $result->get_error_message());
+	}
 }


### PR DESCRIPTION
## Proposed changes

Listen for 403 "Invalid token for url" responses when sending events. Initiate a `reconnect` operation to update the URL in Hiive.

This is a new response from Hiive which is part of fixing a 500 error which occurred when a Site would communicate with Hiive using a valid authentication token but a new URL and the new URL would already have a record in Hiive.

It is safe to release this PR before the changes to Hiive (however unlikely) – this code will behave as before since the 403 will never be received.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I accidentally committed `.editorconfig`. I have some other dev environment changes I'll open another PR for.


