### PR TITLE
Add Hiive Token to Wonder Blocks Platform API requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
     "lint": "Check files against coding standards."
   },
   "require": {
+    "ext-json": "*",
     "newfold-labs/wp-module-loader": "^1.0",
     "wp-forge/helpers": "^2.0",
     "wp-forge/wp-query-builder": "^1.0",
@@ -60,7 +61,6 @@
     "wpscholar/url": "^1.2"
   },
   "require-dev": {
-    "ext-json": "*",
     "10up/wp_mock": "^0.4.2",
     "newfold-labs/wp-php-standards": "^1.2",
     "johnpbloch/wordpress": "*"

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
     "fix": [
       "vendor/bin/phpcbf . --standard=phpcs.xml"
     ],
+    "cs-changes": [
+      "updated_files=$( git status | grep '\\(new file\\|modified\\):\\s.*.php$' | cut -c14- | awk '{ printf(\"%s \", $0) }' ); echo \"\\nChecking\"$(git status | grep '\\(new file\\|modified\\):\\s.*.php$' | tail -n+2 | wc -l)\" files\"; phpcbf $(echo $updated_files); phpcs $(echo $updated_files);"
+    ],
     "lint": [
       "vendor/bin/phpcs . --standard=phpcs.xml -s"
     ]

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
     "wpscholar/url": "^1.2"
   },
   "require-dev": {
+    "ext-json": "*",
     "10up/wp_mock": "^0.4.2",
     "newfold-labs/wp-php-standards": "^1.2",
     "johnpbloch/wordpress": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a2938899238f1e48eafd2e303bc67ee",
+    "content-hash": "8e054ca15005f317dd6ccbf57e23a5c2",
     "packages": [
         {
             "name": "doctrine/inflector",

--- a/includes/WonderBlocks/Requests/Fetch.php
+++ b/includes/WonderBlocks/Requests/Fetch.php
@@ -2,6 +2,9 @@
 
 namespace NewfoldLabs\WP\Module\Data\WonderBlocks\Requests;
 
+use NewfoldLabs\WP\Module\Data\SiteClassification\PrimaryType;
+use NewfoldLabs\WP\Module\Data\SiteClassification\SecondaryType;
+
 /**
  * Class Fetch
  *
@@ -24,14 +27,14 @@ class Fetch extends Request {
 	private $slug;
 
 	/**
-	 * The primary type query parameter. See SiteClassification/PrimaryType for information on primary types.
+	 * The primary type query parameter. {@see PrimaryType} for information on primary types.
 	 *
 	 * @var string
 	 */
 	private $primary_type;
 
 	/**
-	 * The secondary type query parameter. See SiteClassification/SecondaryType for information on secondary types.
+	 * The secondary type query parameter. {@see SecondaryType} for information on secondary types.
 	 *
 	 * @var string
 	 */
@@ -47,23 +50,24 @@ class Fetch extends Request {
 	/**
 	 * Defines whether or not the handler should cache the response data.
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	private $should_cache = true;
 
 	/**
 	 * Defines the timeout for the cache.
 	 *
-	 * @var integer
+	 * @var int
 	 */
-	private $cache_timeout = DAY_IN_SECONDS;
+	private $cache_timeout;
 
 	/**
 	 * Constructor for the Fetch class.
 	 *
-	 * @param array $args An array of arguments that map to the class variables.
+	 * @param array{endpoint?:string,type?:string,slug?:string,primary_type?:string,secondary_string:string,category?:string,should_cache?:bool,cache_timeout?:int} $args An array of arguments that map to the class variables.
 	 */
 	public function __construct( $args = array() ) {
+		$this->cache_timeout = constant( 'DAY_IN_SECONDS' );
 		foreach ( $args as $arg => $value ) {
 			$this->$arg = $value;
 		}
@@ -77,7 +81,7 @@ class Fetch extends Request {
 	public function get_url() {
 		$url = '';
 		if ( isset( $this->endpoint ) ) {
-			$url = self::get_base_url() . "/{$this->endpoint}";
+			$url = $this->get_base_url() . "/{$this->endpoint}";
 			if ( isset( $this->slug ) ) {
 				$url .= "/{$this->slug}";
 			}
@@ -102,28 +106,22 @@ class Fetch extends Request {
 
 	/**
 	 * Determines whether the response for this request should be cached.
-	 *
-	 * @return boolean
 	 */
-	public function should_cache() {
+	public function should_cache(): bool {
 		return $this->should_cache;
 	}
 
 	/**
 	 * Get the cache timeout.
-	 *
-	 * @return integer
 	 */
-	public function get_cache_timeout() {
+	public function get_cache_timeout(): int {
 		return $this->cache_timeout;
 	}
 
 	/**
 	 * Get the MD5 hash to easily identify a request.
-	 *
-	 * @return string
 	 */
-	public function get_md5_hash() {
+	public function get_md5_hash(): string {
 		$args = $this->get_args();
 		// Slug is not part of args as it becomes a part of the URL path.
 		$args['slug'] = $this->slug;

--- a/includes/WonderBlocks/Requests/Fetch.php
+++ b/includes/WonderBlocks/Requests/Fetch.php
@@ -77,7 +77,7 @@ class Fetch extends Request {
 	public function get_url() {
 		$url = '';
 		if ( isset( $this->endpoint ) ) {
-			$url = self::$base_url . "/{$this->endpoint}";
+			$url = self::get_base_url() . "/{$this->endpoint}";
 			if ( isset( $this->slug ) ) {
 				$url .= "/{$this->slug}";
 			}
@@ -129,5 +129,4 @@ class Fetch extends Request {
 		$args['slug'] = $this->slug;
 		return md5( serialize( $args ) );
 	}
-
 }

--- a/includes/WonderBlocks/Requests/Request.php
+++ b/includes/WonderBlocks/Requests/Request.php
@@ -29,11 +29,9 @@ abstract class Request {
 
 	/**
 	 * Get the base URL
-	 *
-	 * @return string
 	 */
-	public static function get_base_url() {
-		if ( defined( 'NFD_DATA_WB_DEV_MODE' ) && NFD_DATA_WB_DEV_MODE ) {
+	public function get_base_url(): string {
+		if ( defined( 'NFD_DATA_WB_DEV_MODE' ) && constant( 'NFD_DATA_WB_DEV_MODE' ) ) {
 			return self::$local_base_url;
 		}
 
@@ -42,17 +40,13 @@ abstract class Request {
 
 	/**
 	 * Get the request endpoint.
-	 *
-	 * @return string
 	 */
-	public function get_endpoint() {
+	public function get_endpoint(): string {
 		return $this->endpoint;
 	}
 
 	/**
 	 * This function should return a MD5 hashed string of the request parameters that can uniquely identify it.
-	 *
-	 * @return void
 	 */
-	abstract public function get_md5_hash();
+	abstract public function get_md5_hash(): string;
 }

--- a/includes/WonderBlocks/Requests/Request.php
+++ b/includes/WonderBlocks/Requests/Request.php
@@ -7,11 +7,18 @@ namespace NewfoldLabs\WP\Module\Data\WonderBlocks\Requests;
  */
 abstract class Request {
 	/**
-	 * The base URL.
+	 * The production base URL.
 	 *
 	 * @var string
 	 */
-	protected static $base_url = 'https://patterns.hiive.cloud';
+	protected static $production_base_url = 'https://patterns.hiive.cloud';
+
+	/**
+	 * The local base URL.
+	 *
+	 * @var string
+	 */
+	protected static $local_base_url = 'http://localhost:8888';
 
 	/**
 	 * The endpoint to request.
@@ -26,7 +33,11 @@ abstract class Request {
 	 * @return string
 	 */
 	public static function get_base_url() {
-		return self::$base_url;
+		if ( defined( 'NFD_DATA_WB_DEV_MODE' ) && NFD_DATA_WB_DEV_MODE ) {
+			return self::$local_base_url;
+		}
+
+		return self::$production_base_url;
 	}
 
 	/**

--- a/includes/WonderBlocks/WonderBlocks.php
+++ b/includes/WonderBlocks/WonderBlocks.php
@@ -20,11 +20,12 @@ class WonderBlocks {
 	 * @return array|false
 	 */
 	public static function fetch( Fetch $request ) {
+
+		// Generate a unique hash for the request object.
+		$hash     = $request->get_md5_hash();
+		$endpoint = $request->get_endpoint();
 		// Do not use cache in development mode.
 		if ( ! self::is_dev_mode() ) {
-			// Generate a unique hash for the request object.
-			$hash     = $request->get_md5_hash();
-			$endpoint = $request->get_endpoint();
 			// If the transient exists, return data from the transient. Add endpoint for batch clearing endpoint transients.
 			$data = get_transient( "nfd_data_wb_{$endpoint}_{$hash}" );
 			if ( ! empty( $data ) ) {

--- a/includes/WonderBlocks/WonderBlocks.php
+++ b/includes/WonderBlocks/WonderBlocks.php
@@ -74,8 +74,8 @@ class WonderBlocks {
 	 * Check is the NFD_DATA_WB_DEV_MODE defined and defined as true.
 	 */
 	protected static function is_dev_mode(): bool {
-		return ! defined( 'NFD_DATA_WB_DEV_MODE' )
-			|| ! constant( 'NFD_DATA_WB_DEV_MODE' );
+		return defined( 'NFD_DATA_WB_DEV_MODE' )
+			&& constant( 'NFD_DATA_WB_DEV_MODE' );
 	}
 
 	/**

--- a/includes/WonderBlocks/WonderBlocks.php
+++ b/includes/WonderBlocks/WonderBlocks.php
@@ -20,8 +20,9 @@ class WonderBlocks {
 	 * @return array|false
 	 */
 	public static function fetch( Fetch $request ) {
-		if ( ! ( defined( 'NFD_DATA_WB_DEV_MODE' ) && NFD_DATA_WB_DEV_MODE ) ) {
-					// Generate a unique hash for the request object.
+		// Do not use cache in development mode.
+		if ( ! self::is_dev_mode() ) {
+			// Generate a unique hash for the request object.
 			$hash     = $request->get_md5_hash();
 			$endpoint = $request->get_endpoint();
 			// If the transient exists, return data from the transient. Add endpoint for batch clearing endpoint transients.
@@ -69,12 +70,19 @@ class WonderBlocks {
 	}
 
 	/**
+	 * Check is the NFD_DATA_WB_DEV_MODE defined and defined as true.
+	 */
+	protected static function is_dev_mode(): bool {
+		return ! defined( 'NFD_DATA_WB_DEV_MODE' )
+			|| ! constant( 'NFD_DATA_WB_DEV_MODE' );
+	}
+
+	/**
 	 * Clear the cache related a particular request object.
 	 *
 	 * @param Request $request An instance of the Request class.
-	 * @return boolean
 	 */
-	public static function clear_cache( Request $request ) {
+	public static function clear_cache( Request $request ): bool {
 		$endpoint = $request->get_endpoint();
 		$hash     = $request->get_md5_hash();
 		return delete_transient( "nfd_data_wb_{$endpoint}_{$hash}" );

--- a/includes/WonderBlocks/WonderBlocks.php
+++ b/includes/WonderBlocks/WonderBlocks.php
@@ -2,6 +2,7 @@
 
 namespace NewfoldLabs\WP\Module\Data\WonderBlocks;
 
+use NewfoldLabs\WP\Module\Data\HiiveConnection;
 use NewfoldLabs\WP\Module\Data\WonderBlocks\Requests\Fetch;
 use NewfoldLabs\WP\Module\Data\WonderBlocks\Requests\Request;
 
@@ -19,22 +20,30 @@ class WonderBlocks {
 	 * @return array|false
 	 */
 	public static function fetch( Fetch $request ) {
-		// Generate a unique hash for the request object.
-		$hash     = $request->get_md5_hash();
-		$endpoint = $request->get_endpoint();
-		// If the transient exists, return data from the transient. Add endpoint for batch clearing endpoint transients.
-		$data = get_transient( "nfd_data_wb_{$endpoint}_{$hash}" );
-		if ( ! empty( $data ) ) {
-			return $data;
+		if ( ! ( defined( 'NFD_DATA_WB_DEV_MODE' ) && NFD_DATA_WB_DEV_MODE ) ) {
+					// Generate a unique hash for the request object.
+			$hash     = $request->get_md5_hash();
+			$endpoint = $request->get_endpoint();
+			// If the transient exists, return data from the transient. Add endpoint for batch clearing endpoint transients.
+			$data = get_transient( "nfd_data_wb_{$endpoint}_{$hash}" );
+			if ( ! empty( $data ) ) {
+				return $data;
+			}
 		}
 
 		$url = $request->get_url();
 		if ( empty( $url ) ) {
 			return false;
 		}
+
 		// Populate valid request arguments.
-		$args['body']   = $request->get_args();
-		$args['method'] = \WP_REST_Server::READABLE;
+		$args = array(
+			'headers' => array(
+				'X-Hiive-Token' => HiiveConnection::get_auth_token(),
+			),
+			'body'    => $request->get_args(),
+			'method'  => \WP_REST_Server::READABLE,
+		);
 
 		$response = wp_remote_request(
 			$url,
@@ -70,5 +79,4 @@ class WonderBlocks {
 		$hash     = $request->get_md5_hash();
 		return delete_transient( "nfd_data_wb_{$endpoint}_{$hash}" );
 	}
-
 }

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,5 +1,6 @@
 {
   "redefinable-internals": [
+    "defined",
     "constant"
   ]
 }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -20,4 +20,7 @@ WP_Mock::activateStrictMode();
 WP_Mock::setUsePatchwork(true);
 WP_Mock::bootstrap();
 
+/** @see \NewfoldLabs\WP\Module\Data\HiiveConnectionTest */
 require_once dirname( __DIR__, 2 ) . '/wordpress/wp-includes/class-wp-error.php';
+/** @see \NewfoldLabs\WP\Module\Data\WonderBlocks\WonderBlocksTest */
+require_once dirname( __DIR__, 2 ) . '/wordpress/wp-includes/rest-api/class-wp-rest-server.php';

--- a/tests/phpunit/includes/WonderBlocks/Requests/FetchTest.php
+++ b/tests/phpunit/includes/WonderBlocks/Requests/FetchTest.php
@@ -2,11 +2,7 @@
 
 namespace NewfoldLabs\WP\Module\Data\WonderBlocks\Requests;
 
-use Mockery;
-use NewfoldLabs\WP\Module\Data\Listeners\Plugin;
-use WP_Mock;
 use WP_Mock\Tools\TestCase;
-use function NewfoldLabs\WP\ModuleLoader\container;
 
 /**
  * @coversDefaultClass \NewfoldLabs\WP\Module\Data\WonderBlocks\Requests\Fetch

--- a/tests/phpunit/includes/WonderBlocks/Requests/FetchTest.php
+++ b/tests/phpunit/includes/WonderBlocks/Requests/FetchTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace NewfoldLabs\WP\Module\Data\WonderBlocks\Requests;
+
+use Mockery;
+use NewfoldLabs\WP\Module\Data\Listeners\Plugin;
+use WP_Mock;
+use WP_Mock\Tools\TestCase;
+use function NewfoldLabs\WP\ModuleLoader\container;
+
+/**
+ * @coversDefaultClass \NewfoldLabs\WP\Module\Data\WonderBlocks\Requests\Fetch
+ */
+class FetchTest extends TestCase {
+
+	public function setUp(): void
+	{
+		\Patchwork\redefine(
+			'constant',
+			function ( string $constant_name ) {
+				switch ($constant_name) {
+					case 'DAY_IN_SECONDS':
+						return 60 * 60 * 24;
+					default:
+						return \Patchwork\relay(func_get_args());
+				}
+			}
+		);
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::get_url
+	 */
+	public function test_get_url_with_endpoint(): void {
+		$args = array(
+			'endpoint' => 'test-endpoint',
+		);
+
+		$sut = new Fetch($args);
+		$result = $sut->get_url();
+		self::assertEquals('https://patterns.hiive.cloud/test-endpoint', $result);
+	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::get_url
+	 */
+	public function test_get_url_with_endpoint_and_slug(): void {
+		$args = array(
+			'endpoint' => 'test-endpoint',
+			'slug' => 'test-slug',
+		);
+
+		$sut = new Fetch($args);
+		$result = $sut->get_url();
+		self::assertEquals('https://patterns.hiive.cloud/test-endpoint/test-slug', $result);
+	}
+}

--- a/tests/phpunit/includes/WonderBlocks/Requests/RequestTest.php
+++ b/tests/phpunit/includes/WonderBlocks/Requests/RequestTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace NewfoldLabs\WP\Module\Data\WonderBlocks\Requests;
+
+use Mockery;
+use NewfoldLabs\WP\Module\Data\Listeners\Plugin;
+use WP_Mock;
+use WP_Mock\Tools\TestCase;
+use function NewfoldLabs\WP\ModuleLoader\container;
+
+/**
+ * @coversDefaultClass \NewfoldLabs\WP\Module\Data\WonderBlocks\Requests\Request
+ */
+class RequestTest extends TestCase {
+
+    /**
+     * @covers ::get_base_url
+     */
+    public function test_get_base_url()
+    {
+        $sut = Mockery::mock(Request::class)->makePartial();
+
+        \Patchwork\redefine(
+            'defined',
+            function ( string $constant_name ) {
+                switch ($constant_name) {
+                    case 'NFD_DATA_WB_DEV_MODE':
+                        return false;
+                    default:
+                        return \Patchwork\relay(func_get_args());
+                }
+            }
+        );
+
+        $result = $sut->get_base_url();
+
+        self::assertEquals('https://patterns.hiive.cloud', $result);
+    }
+
+    /**
+     * @covers ::get_base_url
+     */
+    public function test_get_base_url_dev_mode()
+    {
+        $sut = Mockery::mock(Request::class)->makePartial();
+
+        \Patchwork\redefine(
+            'defined',
+            function ( string $constant_name ) {
+                switch ($constant_name) {
+                    case 'NFD_DATA_WB_DEV_MODE':
+                        return true;
+                    default:
+                        return \Patchwork\relay(func_get_args());
+                }
+            }
+        );
+
+        \Patchwork\redefine(
+            'constant',
+            function ( string $constant_name ) {
+                switch ($constant_name) {
+                    case 'NFD_DATA_WB_DEV_MODE':
+                        return true;
+                    default:
+                        return \Patchwork\relay(func_get_args());
+                }
+            }
+        );
+
+        $result = $sut->get_base_url();
+
+        self::assertEquals('http://localhost:8888', $result);
+    }
+    /**
+     * @covers ::get_base_url
+     */
+    public function test_get_base_url_dev_mode_false()
+    {
+        $sut = Mockery::mock(Request::class)->makePartial();
+
+        \Patchwork\redefine(
+            'defined',
+            function ( string $constant_name ) {
+                switch ($constant_name) {
+                    case 'NFD_DATA_WB_DEV_MODE':
+                        return true;
+                    default:
+                        return \Patchwork\relay(func_get_args());
+                }
+            }
+        );
+
+        \Patchwork\redefine(
+            'constant',
+            function ( string $constant_name ) {
+                switch ($constant_name) {
+                    case 'NFD_DATA_WB_DEV_MODE':
+                        return false;
+                    default:
+                        return \Patchwork\relay(func_get_args());
+                }
+            }
+        );
+
+        $result = $sut->get_base_url();
+
+        self::assertEquals('https://patterns.hiive.cloud', $result);
+    }
+
+    /**
+     * @covers ::get_endpoint
+     */
+    public function test_get_endpoint()
+    {
+        $sut = new class() extends Request {
+            protected $endpoint = 'test-endpoint';
+
+            public function get_md5_hash(): string
+            {
+                return '';
+            }
+        };
+
+        $result = $sut->get_endpoint();
+
+        self::assertEquals('test-endpoint', $result);
+    }
+}

--- a/tests/phpunit/includes/WonderBlocks/Requests/RequestTest.php
+++ b/tests/phpunit/includes/WonderBlocks/Requests/RequestTest.php
@@ -3,10 +3,7 @@
 namespace NewfoldLabs\WP\Module\Data\WonderBlocks\Requests;
 
 use Mockery;
-use NewfoldLabs\WP\Module\Data\Listeners\Plugin;
-use WP_Mock;
 use WP_Mock\Tools\TestCase;
-use function NewfoldLabs\WP\ModuleLoader\container;
 
 /**
  * @coversDefaultClass \NewfoldLabs\WP\Module\Data\WonderBlocks\Requests\Request

--- a/tests/phpunit/includes/WonderBlocks/WonderBlocksTest.php
+++ b/tests/phpunit/includes/WonderBlocks/WonderBlocksTest.php
@@ -3,10 +3,8 @@
 namespace NewfoldLabs\WP\Module\Data\WonderBlocks;
 
 use Mockery;
-use NewfoldLabs\WP\Module\Data\Listeners\Plugin;
 use WP_Mock;
 use WP_Mock\Tools\TestCase;
-use function NewfoldLabs\WP\ModuleLoader\container;
 
 /**
  * @coversDefaultClass \NewfoldLabs\WP\Module\Data\WonderBlocks\WonderBlocks

--- a/tests/phpunit/includes/WonderBlocks/WonderBlocksTest.php
+++ b/tests/phpunit/includes/WonderBlocks/WonderBlocksTest.php
@@ -11,6 +11,12 @@ use WP_Mock\Tools\TestCase;
  */
 class WonderBlocksTest extends TestCase {
 
+	public function setUp(): void {
+		parent::setUp();
+
+		\Patchwork\restoreAll();
+	}
+
 	public function test_request_has_hiive_token(): void {
 
 		$fetch_request = Mockery::mock(Requests\Fetch::class);
@@ -33,6 +39,11 @@ class WonderBlocksTest extends TestCase {
 				}
 			}
 		);
+
+		WP_Mock::userFunction('get_transient')
+		       ->with("nfd_data_wb_test-endpoint_a1b2c3d4e5f6..........32hexchars")
+		       ->once()
+		       ->andReturnFalse();
 
 		$fetch_request->shouldReceive('get_url')
 			->andReturn('https://patterns.hiive.cloud');
@@ -79,6 +90,129 @@ class WonderBlocksTest extends TestCase {
 		$result = WonderBlocks::fetch($fetch_request);
 
 		self::assertEquals('test-success',$result['result']);
+	}
+
+	public function test_request_has_hiive_token_in_dev_mode_no_cached_value(): void {
+
+		$fetch_request = Mockery::mock(Requests\Fetch::class);
+
+		$md5_hash = 'a1b2c3d4e5f6..........32hexchars';
+		$fetch_request->shouldReceive('get_md5_hash')
+		              ->andReturn($md5_hash);
+
+		$endpoint = 'test-endpoint';
+		$fetch_request->shouldReceive('get_endpoint')
+		              ->andReturn($endpoint);
+
+		/** @see WonderBlocks::is_dev_mode() */
+
+		\Patchwork\redefine(
+			'defined',
+			function ( string $constant_name ) {
+				switch ($constant_name) {
+					case 'NFD_DATA_WB_DEV_MODE':
+						return true;
+					default:
+						return \Patchwork\relay(func_get_args());
+				}
+			}
+		);
+
+		\Patchwork\redefine(
+			'constant',
+			function ( string $constant_name ) {
+				switch ($constant_name) {
+					case 'NFD_DATA_WB_DEV_MODE':
+						return true;
+					default:
+						return \Patchwork\relay(func_get_args());
+				}
+			}
+		);
+
+		WP_Mock::userFunction('get_transient')->never();
+
+		$fetch_request->shouldReceive('get_url')
+			->andReturn('https://patterns.hiive.cloud');
+
+		WP_Mock::userFunction('get_option')
+			->with('nfd_data_token')
+			->once()
+			->andReturn('hiive_auth_token');
+
+		$fetch_request->shouldReceive('get_args')
+			->andReturn(array('fetch-args'));
+
+		$test_request_args_for_hiive_auth_token = function() {
+			self::assertEquals( 'https://patterns.hiive.cloud',  func_get_arg(0) );
+			self::assertArrayHasKey( 'headers', func_get_arg(1) );
+			self::assertArrayHasKey( 'X-Hiive-Token', func_get_arg(1)['headers'] );
+			self::assertEquals( 'hiive_auth_token',  func_get_arg(1)['headers']['X-Hiive-Token'] );
+			return true;
+		};
+
+		WP_Mock::userFunction('wp_remote_request')
+			->withArgs($test_request_args_for_hiive_auth_token)
+			->once()
+			->andReturn(array());
+
+		WP_Mock::userFunction('is_wp_error')
+			->with(\WP_Mock\Functions::type( 'array' ))
+			->once()
+			->andReturn(false);
+
+		WP_Mock::userFunction('wp_remote_retrieve_response_code')
+			->with(\WP_Mock\Functions::type( 'array' ))
+			->once()
+			->andReturn(200);
+
+		WP_Mock::userFunction('wp_remote_retrieve_body')
+			->with(\WP_Mock\Functions::type( 'array' ))
+			->once()
+			->andReturn(json_encode(array('data'=>array('result'=>'test-success'))));
+
+		$fetch_request->shouldReceive('should_cache')
+			->andReturnFalse();
+
+		$result = WonderBlocks::fetch($fetch_request);
+
+		self::assertEquals('test-success',$result['result']);
+	}
+
+	public function test_request_has_hiive_token_not_dev_mode_with_cached_value(): void {
+
+		$fetch_request = Mockery::mock(Requests\Fetch::class);
+
+		$md5_hash = 'a1b2c3d4e5f6..........32hexchars';
+		$fetch_request->shouldReceive('get_md5_hash')
+		              ->andReturn($md5_hash);
+
+		$endpoint = 'test-endpoint';
+		$fetch_request->shouldReceive('get_endpoint')
+		              ->andReturn($endpoint);
+
+		/** @see WonderBlocks::is_dev_mode() */
+
+		\Patchwork\redefine(
+			'defined',
+			function ( string $constant_name ) {
+				switch ($constant_name) {
+					case 'NFD_DATA_WB_DEV_MODE':
+						return false;
+					default:
+						return \Patchwork\relay(func_get_args());
+				}
+			}
+		);
+
+		WP_Mock::userFunction('get_transient')
+		       ->with("nfd_data_wb_test-endpoint_a1b2c3d4e5f6..........32hexchars")
+		       ->once()
+		       ->andReturn(array('result'=>'test-success'));
+
+		$result = WonderBlocks::fetch($fetch_request);
+
+		self::assertEquals('test-success', $result['result']);
 	}
 
 }

--- a/tests/phpunit/includes/WonderBlocks/WonderBlocksTest.php
+++ b/tests/phpunit/includes/WonderBlocks/WonderBlocksTest.php
@@ -15,6 +15,13 @@ class WonderBlocksTest extends TestCase {
 
 		$fetch_request = Mockery::mock(Requests\Fetch::class);
 
+		$md5_hash = 'a1b2c3d4e5f6..........32hexchars';
+		$fetch_request->shouldReceive('get_md5_hash')
+		              ->andReturn($md5_hash);
+
+		$fetch_request->shouldReceive('get_endpoint')
+		              ->andReturn('test-endpoint');
+
 		\Patchwork\redefine(
 			'defined',
 			function ( string $constant_name ) {

--- a/tests/phpunit/includes/WonderBlocks/WonderBlocksTest.php
+++ b/tests/phpunit/includes/WonderBlocks/WonderBlocksTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace NewfoldLabs\WP\Module\Data\WonderBlocks;
+
+use Mockery;
+use NewfoldLabs\WP\Module\Data\Listeners\Plugin;
+use WP_Mock;
+use WP_Mock\Tools\TestCase;
+use function NewfoldLabs\WP\ModuleLoader\container;
+
+/**
+ * @coversDefaultClass \NewfoldLabs\WP\Module\Data\WonderBlocks\WonderBlocks
+ */
+class WonderBlocksTest extends TestCase {
+
+	public function test_request_has_hiive_token(): void {
+
+		$fetch_request = Mockery::mock(Requests\Fetch::class);
+
+		\Patchwork\redefine(
+			'defined',
+			function ( string $constant_name ) {
+				switch ($constant_name) {
+					case 'NFD_DATA_WB_DEV_MODE':
+						return false;
+					default:
+						return \Patchwork\relay(func_get_args());
+				}
+			}
+		);
+
+		$fetch_request->shouldReceive('get_url')
+			->andReturn('https://patterns.hiive.cloud');
+
+		WP_Mock::userFunction('get_option')
+			->with('nfd_data_token')
+			->once()
+			->andReturn('hiive_auth_token');
+
+		$fetch_request->shouldReceive('get_args')
+			->andReturn(array('fetch-args'));
+
+		$test_request_args_for_hiive_auth_token = function() {
+			self::assertEquals( 'https://patterns.hiive.cloud',  func_get_arg(0) );
+			self::assertArrayHasKey( 'headers', func_get_arg(1) );
+			self::assertArrayHasKey( 'X-Hiive-Token', func_get_arg(1)['headers'] );
+			self::assertEquals( 'hiive_auth_token',  func_get_arg(1)['headers']['X-Hiive-Token'] );
+			return true;
+		};
+
+		WP_Mock::userFunction('wp_remote_request')
+			->withArgs($test_request_args_for_hiive_auth_token)
+			->once()
+			->andReturn(array());
+
+		WP_Mock::userFunction('is_wp_error')
+			->with(\WP_Mock\Functions::type( 'array' ))
+			->once()
+			->andReturn(false);
+
+		WP_Mock::userFunction('wp_remote_retrieve_response_code')
+			->with(\WP_Mock\Functions::type( 'array' ))
+			->once()
+			->andReturn(200);
+
+		WP_Mock::userFunction('wp_remote_retrieve_body')
+			->with(\WP_Mock\Functions::type( 'array' ))
+			->once()
+			->andReturn(json_encode(array('data'=>array('result'=>'test-success'))));
+
+		$fetch_request->shouldReceive('should_cache')
+			->andReturnFalse();
+
+		$result = WonderBlocks::fetch($fetch_request);
+
+		self::assertEquals('test-success',$result['result']);
+	}
+
+}


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This update adds an `X-Hiive-Token` to all outgoing Wonder Blocks Platform API requests. This goes with https://github.com/newfold-labs/wp-module-patterns/pull/73 which updates the patterns module to utilize the common helpers. The helpers in this folder will become the standard interface for interacting with the Wonder Blocks API platform.
