### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+/.github                export-ignore
+/tests                  export-ignore
+/.editorconfig          export-ignore
+/.env.testing           export-ignore
+/.gitattributes         export-ignore
+/.gitignore             export-ignore
+/.wp-env.json           export-ignore
+/codeception.dist.yml   export-ignore
+/composer.json          export-ignore
+/composer.lock          export-ignore
+/package.json           export-ignore
+/package-lock.json      export-ignore
+/patchwork.json         export-ignore
+/phpcs.xml              export-ignore
+/phpunit.xml.dist       export-ignore
+/readme.md              export-ignore


### PR DESCRIPTION
## Proposed changes

Add a `.gitattributes` file with `export-ignore` directives on development files so they are not included when running `composer install --no-dev --prefer-dist`.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc

## Further comments

* I do see now that they're not included in the plugin release ([release workflow](https://github.com/bluehost/bluehost-wordpress-plugin/blob/43b1536a6b33a018076eeba636b7ddd0a70364c2/.github/workflows/upload-asset-on-release.yml#L106)). Adding a `.gitattributes` file allows controlling it at the source repo rather than needing a PR in the consuming repos when new files to ignore are added. 
* I think this only takes effect when installing a tag/release version, rather than `dev-main`. I.e. when testing with ~`composer require "newfold-labs/wp-module-data":"dev-add/gitattributes-file as 2.4.24"; composer install --no-dev --prefer-dist;` the files were not excluded.