### PR TITLE
Update/npm wp-env and port config

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,8 @@
 {
-  "phpVersion": "7.3"
+    "phpVersion": "7.3",
+    "env": {
+        "tests": {
+            "mysqlPort": 62088
+        }
+    }
 }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,9 @@
     "": {
       "name": "wp-module-data",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "GPL-2.0-or-later",
       "devDependencies": {
-        "@wordpress/env": "^9.9.0"
+        "@wordpress/env": "^10.1"
       }
     },
     "node_modules/@kwsites/file-exists": {
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-9.9.0.tgz",
-      "integrity": "sha512-uV7OwnNS8XL/Nx8PHShsxin0P2s81NbJl8jaFKG4XuZFrl+Ha4AQdypmJFdTOTRqQgvlWnZ25jhr0iQtXq1aOg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.1.0.tgz",
+      "integrity": "sha512-kctjcTTWlQlG2IjjQGTLK/1Z6P4pl2W7Z34gbOR0eouqHlfJ7lJ44HXsHKUbNwIPzU7a/iLCT/N1B1b0TNu66Q==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -140,6 +140,10 @@
       },
       "bin": {
         "wp-env": "bin/wp-env"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/ansi-escapes": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "author": "",
   "license": "GPL-2.0-or-later",
   "devDependencies": {
-    "@wordpress/env": "^9.9.0"
+    "@wordpress/env": "^10.1"
   }
 }


### PR DESCRIPTION
## Proposed changes

`npm install @wordpress/env@^10.1`

and add the new config that that allows to `.wp-env.json`

```
    "env": {
        "tests": {
            "mysqlPort": 62088
        }
    }
```

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This is the result of an earlier PR to Gutenberg: https://github.com/WordPress/gutenberg/pull/61057