### PR TITLE
Workflow: delete and recreate directory for codecoverage

### DIFF
--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -78,9 +78,9 @@ jobs:
         run: sudo chmod -R a+w wp-content
 
       - name: Clear previous code coverage
-        working-directory: gh-pages/phpunit
         run: |
-          rm -rf *
+          rm -rf gh-pages/phpunit || true;
+          mkdir gh-pages/phpunit || true;
 
       - name: Run unit tests
         run: XDEBUG_MODE=coverage phpunit --bootstrap tests/phpunit/bootstrap.php --coverage-php tests/_output/unit.cov || true;


### PR DESCRIPTION
## Proposed changes

There was a problem with the workflow where it tried to set the current working directory to one that didn't yet exist

```
Run rm -rf *
```
> Error: An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/wp-module-data/wp-module-data/gh-pages/phpunit'. No such file or directory

This fix deletes and recreates the directory from the project root instead.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

## Further comments

