### PR TITLE
Fix/phpunit path vendor bin; enable gh-pages

### DIFF
--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -83,7 +83,7 @@ jobs:
           mkdir gh-pages/phpunit || true;
 
       - name: Run unit tests
-        run: XDEBUG_MODE=coverage phpunit --bootstrap tests/phpunit/bootstrap.php --coverage-php tests/_output/unit.cov || true;
+        run: XDEBUG_MODE=coverage vendor/bin/phpunit --bootstrap tests/phpunit/bootstrap.php --coverage-php tests/_output/unit.cov || true;
 
       - name: Run wpunit tests
         run: XDEBUG_MODE=coverage vendor/bin/codecept run wpunit --coverage tests/_output/wpunit.cov --debug || true;

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -51,6 +51,9 @@ jobs:
           allow_empty_commit: true
           commit_message: "🤖 Creating gh-pages branch"
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
       - name: Checkout GitHub Pages branch for code coverage report
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Proposed changes

Fix: `phpunit` not found because missing `vendor/bin`
Fix: gh-pages, although the files were deployed the setting was not enabled (not 1000% confident this is the fix)

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

