### PR TITLE
Remove code to enable gh-pages; it requires a PAT

### DIFF
--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -51,11 +51,6 @@ jobs:
           allow_empty_commit: true
           commit_message: "🤖 Creating gh-pages branch"
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-        with:
-          enablement: true
-
       - name: Checkout GitHub Pages branch for code coverage report
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Remove step which cannot work without a personal access token.

Enabled gh-pages manually in https://github.com/newfold-labs/wp-module-data/settings/pages

See: https://github.com/actions/configure-pages/issues/40
