### PR TITLE
Update link to HTML code coverage report

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![PHPUnit ](https://newfold-labs.github.io/wp-module-data/phpunit/coverage.svg)](https://newfold-labs.github.io/wp-module-data)
+[![PHPUnit ](https://newfold-labs.github.io/wp-module-data/phpunit/coverage.svg)](https://newfold-labs.github.io/wp-module-data/phpunit/html)
 
 <a href="https://newfold.com/" target="_blank">
   <img src="https://newfold.com/content/experience-fragments/newfold/site-header/master/_jcr_content/root/header/logo.coreimg.svg/1621395071423/newfold-digital.svg" alt="Newfold Logo" title="Newfold Digital" align="right" height="42" />


### PR DESCRIPTION
## Proposed changes

[![PHPUnit ](https://newfold-labs.github.io/wp-module-data/phpunit/coverage.svg)](https://newfold-labs.github.io/wp-module-data/phpunit/html)

The link was pointed to the root gh-pages site rather than the code coverage report

* https://newfold-labs.github.io/wp-module-data/
* https://newfold-labs.github.io/wp-module-data/phpunit/html

