### PR TITLE
Add a getter to fetch the private member 'api' of HiiveConnection

### DIFF
--- a/includes/HiiveConnection.php
+++ b/includes/HiiveConnection.php
@@ -46,6 +46,15 @@ class HiiveConnection implements SubscriberInterface {
 	}
 
 	/**
+	 * Return the Hiive API URL
+	 *
+	 * @return string The Hiive API URL
+	 */
+	protected function get_api_url() {
+		return $this->api;
+	}
+
+	/**
 	 * Register the hooks required for site verification
 	 *
 	 * @return void


### PR DESCRIPTION
## Proposed changes

This PR adds a getter function which will be useful in other modules when the HiiveConnection is being reused. Example: https://github.com/newfold-labs/wp-module-products/pull/1