### PR TITLE
Fix PR 76 bugs

### DIFF
--- a/includes/EventManager.php
+++ b/includes/EventManager.php
@@ -215,14 +215,14 @@ class EventManager {
 				continue;
 			}
 
-			$queue = EventQueue::getInstance()->queue();
-
 			if ( is_wp_error( $response ) ) {
 				EventQueue::getInstance()->queue()->push( $events );
 				continue;
 			}
 
-			EventQueue::getInstance()->queue()->push( $response['failedEvents'] );
+			if ( ! empty( $response['failedEvents'] ) ) {
+				EventQueue::getInstance()->queue()->push( $response['failedEvents'] );
+			}
 		}
 	}
 
@@ -265,10 +265,14 @@ class EventManager {
 			}
 
 			// Remove from the queue.
-			$queue->remove( array_keys( $response['succeededEvents'] ) );
+			if ( ! empty( $response['succeededEvents'] ) ) {
+				$queue->remove( array_keys( $response['succeededEvents'] ) );
+			}
 
 			// Release the 'reserve' we placed on the entry, so it will be tried again later.
-			$queue->release( array_keys( $response['failedEvents'] ) );
+			if ( ! empty( $response['failedEvents'] ) ) {
+				$queue->release( array_keys( $response['failedEvents'] ) );
+			}
 		}
 	}
 }

--- a/includes/EventQueue/Queryable.php
+++ b/includes/EventQueue/Queryable.php
@@ -27,7 +27,7 @@ trait Queryable {
 	 * Returns number of affected (inserted) rows.
 	 *
 	 * @param  string  $table
-	 * @param  array[]  $rows
+	 * @param  non-empty-array  $rows
 	 *
 	 * @return bool|int
 	 */

--- a/includes/EventQueue/Queues/BatchQueue.php
+++ b/includes/EventQueue/Queues/BatchQueue.php
@@ -29,7 +29,7 @@ class BatchQueue implements BatchQueueInterface {
 	/**
 	 * Push events onto the queue
 	 *
-	 * @param  Event[]  $events
+	 * @param  non-empty-array<Event>  $events
 	 *
 	 * @return bool
 	 */

--- a/includes/Helpers/Plugin.php
+++ b/includes/Helpers/Plugin.php
@@ -50,9 +50,9 @@ class Plugin {
 	/**
 	 * Grab relevant data from plugin data - and only what we want
 	 *
-	 * @param array $slug The slug for the plugin
-	 * @param array $data The plugin meta data from the header
-	 * @param array $mu   Whether the plugin is installed as an mu
+	 * @param string $slug The slug for the plugin.
+	 * @param array  $data The plugin meta-data from its header.
+	 * @param array  $mu   Whether the plugin is installed as a must-use plugin.
 	 *
 	 * @return array Hiive relevant plugin details
 	 */

--- a/includes/HiiveConnection.php
+++ b/includes/HiiveConnection.php
@@ -344,7 +344,7 @@ class HiiveConnection implements SubscriberInterface {
 			$body = json_decode( $request_response['body'], true );
 			if ( 'Invalid token for url' === $body['message'] ) {
 				if ( $this->reconnect() ) {
-					$this->hiive_request( $path, $args );
+					$this->hiive_request( $path, $payload, $args );
 				} else {
 					return new WP_Error( 'hiive_connection', __( 'This site is not connected to the hiive.' ) );
 				}

--- a/includes/HiiveConnection.php
+++ b/includes/HiiveConnection.php
@@ -319,8 +319,8 @@ class HiiveConnection implements SubscriberInterface {
 		$defaults = array(
 			'method'  => 'POST',
 			'headers' => array(
-				'Content-Type'  => 'applicaton/json',
-				'Accept'        => 'applicaton/json',
+				'Content-Type'  => 'application/json',
+				'Accept'        => 'application/json',
 				'Authorization' => 'Bearer ' . self::get_auth_token(),
 			),
 			'timeout' => wp_is_serving_rest_request() ? 15 : 60, // If we're responding to the frontend, we need to be quick.

--- a/tests/phpunit/includes/EventManagerTest.php
+++ b/tests/phpunit/includes/EventManagerTest.php
@@ -474,8 +474,7 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 						->once()
 						->with( array( 19 ) );
 
-		$batch_queue_mock->expects( 'remove' )->once()
-			->with( array() );
+		$batch_queue_mock->expects( 'remove' )->never();
 
 		$sut->send_saved_events_batch();
 

--- a/tests/phpunit/includes/EventManagerTest.php
+++ b/tests/phpunit/includes/EventManagerTest.php
@@ -197,12 +197,15 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 		$hiive_connection_subscriber->expects( 'notify' )
 			->once()
 			->andReturn(
-				array( 'succeededEvents' => array( 15 => array() ), 'failedEvents' => array() )
+				array(
+					'succeededEvents' => array( 15 => array() ),
+					'failedEvents'    => array( 16 => array() ),
+				)
 			);
 
 		WP_Mock::userFunction( 'is_wp_error' )
-		       ->once()
-		       ->andReturnFalse();
+				->once()
+				->andReturnFalse();
 
 		$batch_queue_mock->expects( 'remove' )
 						->once()
@@ -210,7 +213,141 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 		$batch_queue_mock->expects( 'release' )
 						->once()
-						->with( array() );
+						->with( array( 16 ) );
+
+		$sut->send_saved_events_batch();
+
+		$this->assertConditionsMet();
+	}
+
+	/**
+	 * @covers ::send_saved_events_batch
+	 * @covers ::send
+	 */
+	public function test_send_saved_events_happy_path_no_failed_events(): void {
+
+		$batch_queue_mock = Mockery::mock( BatchQueue::class );
+
+		\Patchwork\redefine(
+			array( EventQueue::class, '__construct' ),
+			function () {}
+		);
+		\Patchwork\redefine(
+			array( EventQueue::class, 'queue' ),
+			function () use ( $batch_queue_mock ) {
+				return $batch_queue_mock;
+			}
+		);
+
+		$sut = Mockery::mock( EventManager::class )->makePartial();
+
+		$event = Mockery::mock( Event::class );
+
+		$batch_queue_mock->expects( 'pull' )
+						->once()
+						->with( 100 )
+						->andReturn(
+							array(
+								15 => $event,
+							)
+						);
+
+		$batch_queue_mock->expects( 'reserve' )
+						->once()
+						->with( array( 15 ) );
+
+		$hiive_connection_subscriber = Mockery::mock( HiiveConnection::class );
+
+		$sut->expects( 'get_subscribers' )
+			->once()
+			->andReturn( array( $hiive_connection_subscriber ) );
+
+		$hiive_connection_subscriber->expects( 'notify' )
+			->once()
+			->andReturn(
+				array(
+					'succeededEvents' => array( 15 => array() ),
+					'failedEvents'    => array(),
+				)
+			);
+
+		WP_Mock::userFunction( 'is_wp_error' )
+				->once()
+				->andReturnFalse();
+
+		$batch_queue_mock->expects( 'remove' )
+						->once()
+						->with( array( 15 ) );
+
+		$batch_queue_mock->expects( 'release' )
+						->never();
+
+		$sut->send_saved_events_batch();
+
+		$this->assertConditionsMet();
+	}
+
+	/**
+	 * @covers ::send_saved_events_batch
+	 * @covers ::send
+	 */
+	public function test_send_saved_events_happy_path_no_successful_events(): void {
+
+		$batch_queue_mock = Mockery::mock( BatchQueue::class );
+
+		\Patchwork\redefine(
+			array( EventQueue::class, '__construct' ),
+			function () {}
+		);
+		\Patchwork\redefine(
+			array( EventQueue::class, 'queue' ),
+			function () use ( $batch_queue_mock ) {
+				return $batch_queue_mock;
+			}
+		);
+
+		$sut = Mockery::mock( EventManager::class )->makePartial();
+
+		$event = Mockery::mock( Event::class );
+
+		$batch_queue_mock->expects( 'pull' )
+						->once()
+						->with( 100 )
+						->andReturn(
+							array(
+								15 => $event,
+							)
+						);
+
+		$batch_queue_mock->expects( 'reserve' )
+						->once()
+						->with( array( 15 ) );
+
+		$hiive_connection_subscriber = Mockery::mock( HiiveConnection::class );
+
+		$sut->expects( 'get_subscribers' )
+			->once()
+			->andReturn( array( $hiive_connection_subscriber ) );
+
+		$hiive_connection_subscriber->expects( 'notify' )
+			->once()
+			->andReturn(
+				array(
+					'succeededEvents' => array(),
+					'failedEvents'    => array( 16 => array() ),
+				)
+			);
+
+		WP_Mock::userFunction( 'is_wp_error' )
+				->once()
+				->andReturnFalse();
+
+		$batch_queue_mock->expects( 'remove' )
+						->never();
+
+		$batch_queue_mock->expects( 'release' )
+						->once()
+						->with( array( 16 ) );
 
 		$sut->send_saved_events_batch();
 
@@ -323,7 +460,10 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 		$hiive_connection_subscriber->expects( 'notify' )
 			->once()
 			->andReturn(
-				array( 'succeededEvents' => array(), 'failedEvents' => array( 19 => array() ) )
+				array(
+					'succeededEvents' => array(),
+					'failedEvents'    => array( 19 => array() ),
+				)
 			);
 
 		WP_Mock::userFunction( 'is_wp_error' )
@@ -344,9 +484,9 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 	/**
 	 * @covers ::shutdown
-	 * @covers ::send
+	 * @covers ::send_request_events
 	 */
-	public function test_shutdown_happy_path(): void {
+	public function test_shutdown_happy_path_no_failed_events(): void {
 
 		$sut = new EventManager();
 
@@ -375,7 +515,60 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 		$hiive_connection_subscriber->expects( 'notify' )
 									->once()
 									->andReturn(
-										array( 'succeededEvents' => array(), 'failedEvents' => array( 2 => array( 'key' => 'test' ) ) )
+										array(
+											'succeededEvents' => array(),
+											'failedEvents' => array(),
+										)
+									);
+
+		WP_Mock::userFunction( 'is_wp_error' )
+				->once()
+				->andReturnFalse();
+
+		$batch_queue_mock->expects( 'push' )->never();
+
+		$sut->shutdown();
+
+		$this->assertConditionsMet();
+	}
+
+	/**
+	 * @covers ::shutdown
+	 * @covers ::send_request_events
+	 */
+	public function test_shutdown_happy_path_with_failed_events(): void {
+
+		$sut = new EventManager();
+
+		$event      = Mockery::mock( Event::class )->makePartial();
+		$event->key = 'test';
+
+		$sut->push( $event );
+
+		$batch_queue_mock = Mockery::mock( BatchQueue::class );
+
+		\Patchwork\redefine(
+			array( EventQueue::class, '__construct' ),
+			function () {}
+		);
+		\Patchwork\redefine(
+			array( EventQueue::class, 'queue' ),
+			function () use ( $batch_queue_mock ) {
+				return $batch_queue_mock;
+			}
+		);
+
+		$hiive_connection_subscriber = Mockery::mock( HiiveConnection::class );
+
+		$sut->add_subscriber( $hiive_connection_subscriber );
+
+		$hiive_connection_subscriber->expects( 'notify' )
+									->once()
+									->andReturn(
+										array(
+											'succeededEvents' => array(),
+											'failedEvents' => array( 2 => array( 'key' => 'test' ) ),
+										)
 									);
 
 		WP_Mock::userFunction( 'is_wp_error' )
@@ -383,7 +576,7 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 				->andReturnFalse();
 
 		$batch_queue_mock->expects( 'push' )->once()
-			->with(array( 2 => array( 'key' => 'test' ) ));
+			->with( array( 2 => array( 'key' => 'test' ) ) );
 
 		$sut->shutdown();
 
@@ -469,7 +662,10 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 		$hiive_connection_subscriber->expects( 'notify' )
 									->once()
 									->andReturn(
-										array( 'succeededEvents' => array(), 'failedEvents' => array( 18 => array( 'key' => 'event ') ) )
+										array(
+											'succeededEvents' => array(),
+											'failedEvents' => array( 18 => array( 'key' => 'event ' ) ),
+										)
 									);
 
 		WP_Mock::userFunction( 'is_wp_error' )
@@ -477,7 +673,7 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 				->andReturnFalse();
 
 		$batch_queue_mock->expects( 'push' )->once()
-		->with(array( 18 => array( 'key' => 'event ') ));
+		->with( array( 18 => array( 'key' => 'event ' ) ) );
 
 		$sut->shutdown();
 

--- a/tests/phpunit/includes/HiiveConnectionTest.php
+++ b/tests/phpunit/includes/HiiveConnectionTest.php
@@ -25,7 +25,11 @@ class HiiveConnectionTest extends TestCase {
 		);
 		WP_Mock::userFunction( 'wp_parse_args' )->andReturnUsing(
 			function () {
-				return array_merge( func_get_args() );
+				$merged = array();
+				foreach ( func_get_args() as $arr ) {
+					$merged = array_merge( $merged, $arr );
+				}
+				return $merged;
 			}
 		);
 	}
@@ -182,7 +186,13 @@ class HiiveConnectionTest extends TestCase {
 	public function test_notify_bad_token(): void {
 		$sut = Mockery::mock( HiiveConnection::class )->makePartial();
 
-		$event = Mockery::mock( Event::class );
+		$event           = Mockery::mock( Event::class );
+		$event->category = 'admin';
+		$event->key      = 'plugin_search';
+		$event->data     = array(
+			'type'  => 'term',
+			'query' => 'seo',
+		);
 
 		WP_Mock::userFunction( 'get_option' )
 			->with( 'nfd_data_token' )
@@ -197,8 +207,18 @@ class HiiveConnectionTest extends TestCase {
 		$sut->expects( 'get_core_data' )->times( 2 )->andReturn( array( 'brand' => 'etc' ) );
 
 		WP_Mock::userFunction( 'wp_remote_request' )
-			->with( '/sites/v2/events', \WP_Mock\Functions::type( 'array' ) )
-			->twice()->andReturnValues(
+			->withArgs(
+				function ( $url, $args ) {
+					assert( '/sites/v2/events' === $url );
+
+					$body = json_decode( $args['body'], true );
+					assert( 'seo' === $body['events'][0]['data']['query'] );
+
+					return true;
+				}
+			)
+			->twice()
+			->andReturnValues(
 				array(
 					array(
 						'response' => array(

--- a/tests/phpunit/includes/HiiveConnectionTest.php
+++ b/tests/phpunit/includes/HiiveConnectionTest.php
@@ -214,6 +214,9 @@ class HiiveConnectionTest extends TestCase {
 					$body = json_decode( $args['body'], true );
 					assert( 'seo' === $body['events'][0]['data']['query'] );
 
+					assert( 'application/json' === $args['headers']['Content-Type'] );
+					assert( 'application/json' === $args['headers']['Accept'] );
+
 					return true;
 				}
 			)

--- a/tests/wpunit/includes/EventManagerWPUnitTest.php
+++ b/tests/wpunit/includes/EventManagerWPUnitTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace NewfoldLabs\WP\Module\Data;
+
+use Mockery;
+use function NewfoldLabs\WP\ModuleLoader\container;
+
+/**
+ * @coversDefaultClass \NewfoldLabs\WP\Module\Data\EventManager
+ */
+class EventManagerWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase {
+	/**
+	 * 2.6.0 was released with a bug where an empty array was passed to the Queue to be saved, causing a fatal error.
+	 *
+	 * "Undefined offset: 0 at includes/EventQueue/Queryable.php:38"
+	 *
+	 * @see https://github.com/newfold-labs/wp-module-data/releases/tag/2.6.0
+	 *
+	 * @covers ::shutdown
+	 * @covers ::send_request_events
+	 */
+	public function test_empty_response_from_hiive(): void {
+		$sut = new EventManager();
+
+		$event           = Mockery::mock( Event::class );
+		$event->category = 'admin';
+		$event->key      = 'plugin_search';
+		$event->data     = array(
+			'type'  => 'term',
+			'query' => 'seo',
+		);
+
+		$sut->push( $event );
+
+		$hiive_connection = Mockery::mock( HiiveConnection::class );
+		$hiive_connection->expects('notify' )
+			->once()
+			->andReturn(
+				array(
+					'succeededEvents' => array(),
+					'failedEvents'    => array(),
+				)
+			);
+
+		$sut->add_subscriber( $hiive_connection );
+
+		$sut->shutdown();
+	}
+}


### PR DESCRIPTION
## Proposed changes

* Do not pass empty arrays to BatchQueue functions
* Fix recursive call arguments after Hiive reconnect
* Fix Content-Type and Accept header spelling
* Handle HTTP 500 from Hiive which do not contain array with `succeededEvents` and `failedEvents`

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
