### PR TITLE
Stop retrying events

### DIFF
--- a/includes/EventManager.php
+++ b/includes/EventManager.php
@@ -247,7 +247,12 @@ class EventManager {
 			return;
 		}
 
-		$queue->reserve( array_keys( $events ) );
+		// Reserve the events in the queue so they are not processed by another instance.
+		if ( ! $queue->reserve( array_keys( $events ) ) ) {
+			// If the events fail to reserve, they will be repeatedly retried.
+			// It would be good to log this somewhere.
+			return;
+		}
 
 		foreach ( $this->get_subscribers() as $subscriber ) {
 			/**

--- a/includes/EventManager.php
+++ b/includes/EventManager.php
@@ -272,7 +272,6 @@ class EventManager {
 			$response = $subscriber->notify( $events );
 
 			// Due to an unidentified bug causing events to be resent, we are temporarily disabling retries.
-			$queue->remove( array_keys( $events ) );
 			continue;
 
 			if ( ! ( $subscriber instanceof HiiveConnection ) ) {
@@ -294,5 +293,8 @@ class EventManager {
 				$queue->release( array_keys( $response['failedEvents'] ) );
 			}
 		}
+
+		// Due to an unidentified bug causing events to be resent, we are temporarily disabling retries.
+		$queue->remove( array_keys( $events ) );
 	}
 }

--- a/includes/EventManager.php
+++ b/includes/EventManager.php
@@ -211,6 +211,9 @@ class EventManager {
 			 */
 			$response = $subscriber->notify( $events );
 
+			// Due to an unidentified bug causing events to be resent, we are temporarily disabling retries.
+			continue;
+
 			if ( ! ( $subscriber instanceof HiiveConnection ) ) {
 				continue;
 			}
@@ -259,6 +262,10 @@ class EventManager {
 			 * @var array{succeededEvents:array,failedEvents:array}|WP_Error $response
 			 */
 			$response = $subscriber->notify( $events );
+
+			// Due to an unidentified bug causing events to be resent, we are temporarily disabling retries.
+			$queue->remove( array_keys( $events ) );
+			continue;
 
 			if ( ! ( $subscriber instanceof HiiveConnection ) ) {
 				continue;

--- a/includes/EventManager.php
+++ b/includes/EventManager.php
@@ -251,7 +251,7 @@ class EventManager {
 		 *
 		 * @var array<int,Event> $events
 		 */
-		$events = $queue->pull( 100 );
+		$events = $queue->pull( 50 );
 
 		// If queue is empty, do nothing.
 		if ( empty( $events ) ) {

--- a/includes/EventManager.php
+++ b/includes/EventManager.php
@@ -121,6 +121,14 @@ class EventManager {
 	 */
 	public function shutdown(): void {
 
+		// Due to a bug sending too many events, we are temporarily disabling these.
+		$disabled_events = array( 'pageview', 'wp_mail', 'plugin_updated' );
+		foreach ( $this->queue as $index => $event ) {
+			if ( in_array( $event->key, $disabled_events, true ) ) {
+				unset( $this->queue[ $index ] );
+			}
+		}
+
 		// Separate out the async events
 		$async = array();
 		foreach ( $this->queue as $index => $event ) {

--- a/tests/phpunit/includes/EventManagerTest.php
+++ b/tests/phpunit/includes/EventManagerTest.php
@@ -228,7 +228,7 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 	public function test_send_saved_events_happy_path_no_failed_events(): void {
 
 		$this->markTestSkipped( 'Due to an unidentified bug causing events to be resent, we are temporarily disabling retries.' );
-		
+
 		$batch_queue_mock = Mockery::mock( BatchQueue::class );
 
 		\Patchwork\redefine(
@@ -317,7 +317,7 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 		$batch_queue_mock->expects( 'pull' )
 						->once()
-						->with( 100 )
+						->with( 50 )
 						->andReturn(
 							array(
 								15 => $event,
@@ -386,7 +386,7 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 		$batch_queue_mock->expects( 'pull' )
 						->once()
-						->with( 100 )
+						->with( 50 )
 						->andReturn(
 							array(
 								15 => $event,
@@ -449,7 +449,7 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 		$batch_queue_mock->expects( 'pull' )
 						->once()
-						->with( 100 )
+						->with( 50 )
 						->andReturn(
 							array(
 								16 => $event,
@@ -721,7 +721,7 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 		$batch_queue_mock->expects( 'pull' )
 						->once()
-						->with( 100 )
+						->with( 50 )
 						->andReturn(
 							array(
 								15 => $event,

--- a/tests/phpunit/includes/EventManagerTest.php
+++ b/tests/phpunit/includes/EventManagerTest.php
@@ -154,7 +154,6 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 	/**
 	 * @covers ::send_saved_events_batch
-	 * @covers ::send
 	 */
 	public function test_send_saved_events_happy_path(): void {
 
@@ -223,7 +222,6 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 	/**
 	 * @covers ::send_saved_events_batch
-	 * @covers ::send
 	 */
 	public function test_send_saved_events_happy_path_no_failed_events(): void {
 
@@ -291,7 +289,6 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 	/**
 	 * @covers ::send_saved_events_batch
-	 * @covers ::send
 	 */
 	public function test_send_saved_events_happy_path_no_successful_events(): void {
 
@@ -359,7 +356,6 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 	/**
 	 * @covers ::send_saved_events_batch
-	 * @covers ::send
 	 */
 	public function test_send_saved_events_wp_error_from_hiive_connection(): void {
 
@@ -421,7 +417,6 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 	/**
 	 * @covers ::send_saved_events_batch
-	 * @covers ::send
 	 */
 	public function test_send_saved_events_failures_from_hiive(): void {
 
@@ -589,7 +584,7 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 	/**
 	 * @covers ::shutdown
-	 * @covers ::send
+	 * @covers ::send_request_events
 	 */
 	public function test_shutdown_hiive_connection_wp_error(): void {
 
@@ -635,7 +630,7 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 	/**
 	 * @covers ::shutdown
-	 * @covers ::send
+	 * @covers ::send_request_events
 	 */
 	public function test_shutdown_hiive_500_error(): void {
 

--- a/tests/phpunit/includes/EventManagerTest.php
+++ b/tests/phpunit/includes/EventManagerTest.php
@@ -186,7 +186,8 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 		$batch_queue_mock->expects( 'reserve' )
 						->once()
-						->with( array( 15 ) );
+						->with( array( 15 ) )
+						->andReturnTrue();
 
 		$hiive_connection_subscriber = Mockery::mock( HiiveConnection::class );
 
@@ -254,7 +255,8 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 		$batch_queue_mock->expects( 'reserve' )
 						->once()
-						->with( array( 15 ) );
+						->with( array( 15 ) )
+						->andReturnTrue();
 
 		$hiive_connection_subscriber = Mockery::mock( HiiveConnection::class );
 
@@ -321,7 +323,8 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 		$batch_queue_mock->expects( 'reserve' )
 						->once()
-						->with( array( 15 ) );
+						->with( array( 15 ) )
+						->andReturnTrue();
 
 		$hiive_connection_subscriber = Mockery::mock( HiiveConnection::class );
 
@@ -388,7 +391,8 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 		$batch_queue_mock->expects( 'reserve' )
 						->once()
-						->with( array( 15 ) );
+						->with( array( 15 ) )
+						->andReturnTrue();
 
 		$hiive_connection_subscriber = Mockery::mock( HiiveConnection::class );
 
@@ -449,7 +453,8 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 
 		$batch_queue_mock->expects( 'reserve' )
 						->once()
-						->with( array( 16 ) );
+						->with( array( 16 ) )
+						->andReturnTrue();
 
 		$hiive_connection_subscriber = Mockery::mock( HiiveConnection::class );
 
@@ -675,6 +680,49 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 		->with( array( 18 => array( 'key' => 'event ' ) ) );
 
 		$sut->shutdown();
+
+		$this->assertConditionsMet();
+	}
+
+	/**
+	 * @covers ::send_saved_events_batch
+	 */
+	public function test_send_saved_events_reserve_fails(): void {
+
+		$batch_queue_mock = Mockery::mock( BatchQueue::class );
+
+		\Patchwork\redefine(
+			array( EventQueue::class, '__construct' ),
+			function () {}
+		);
+		\Patchwork\redefine(
+			array( EventQueue::class, 'queue' ),
+			function () use ( $batch_queue_mock ) {
+				return $batch_queue_mock;
+			}
+		);
+
+		$sut = Mockery::mock( EventManager::class )->makePartial();
+
+		$event = Mockery::mock( Event::class );
+
+		$batch_queue_mock->expects( 'pull' )
+						->once()
+						->with( 100 )
+						->andReturn(
+							array(
+								15 => $event,
+							)
+						);
+
+		$batch_queue_mock->expects( 'reserve' )
+						->once()
+						->with( array( 15 ) )
+						->andReturnFalse();
+
+		$sut->expects( 'get_subscribers' )->never();
+
+		$sut->send_saved_events_batch();
 
 		$this->assertConditionsMet();
 	}

--- a/tests/phpunit/includes/EventManagerTest.php
+++ b/tests/phpunit/includes/EventManagerTest.php
@@ -157,6 +157,8 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 	 */
 	public function test_send_saved_events_happy_path(): void {
 
+		$this->markTestSkipped( 'Due to an unidentified bug causing events to be resent, we are temporarily disabling retries.' );
+
 		$batch_queue_mock = Mockery::mock( BatchQueue::class );
 
 		\Patchwork\redefine(
@@ -225,6 +227,8 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 	 */
 	public function test_send_saved_events_happy_path_no_failed_events(): void {
 
+		$this->markTestSkipped( 'Due to an unidentified bug causing events to be resent, we are temporarily disabling retries.' );
+		
 		$batch_queue_mock = Mockery::mock( BatchQueue::class );
 
 		\Patchwork\redefine(
@@ -291,6 +295,8 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 	 * @covers ::send_saved_events_batch
 	 */
 	public function test_send_saved_events_happy_path_no_successful_events(): void {
+
+		$this->markTestSkipped( 'Due to an unidentified bug causing events to be resent, we are temporarily disabling retries.' );
 
 		$batch_queue_mock = Mockery::mock( BatchQueue::class );
 
@@ -359,6 +365,8 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 	 */
 	public function test_send_saved_events_wp_error_from_hiive_connection(): void {
 
+		$this->markTestSkipped( 'Due to an unidentified bug causing events to be resent, we are temporarily disabling retries.' );
+
 		$batch_queue_mock = Mockery::mock( BatchQueue::class );
 
 		\Patchwork\redefine(
@@ -419,6 +427,8 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 	 * @covers ::send_saved_events_batch
 	 */
 	public function test_send_saved_events_failures_from_hiive(): void {
+
+		$this->markTestSkipped( 'Due to an unidentified bug causing events to be resent, we are temporarily disabling retries.' );
 
 		$batch_queue_mock = Mockery::mock( BatchQueue::class );
 
@@ -487,6 +497,8 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 	 */
 	public function test_shutdown_happy_path_no_failed_events(): void {
 
+		$this->markTestSkipped( 'Due to an unidentified bug causing events to be resent, we are temporarily disabling retries.' );
+
 		$sut = new EventManager();
 
 		$event      = Mockery::mock( Event::class )->makePartial();
@@ -536,6 +548,8 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 	 * @covers ::send_request_events
 	 */
 	public function test_shutdown_happy_path_with_failed_events(): void {
+
+		$this->markTestSkipped( 'Due to an unidentified bug causing events to be resent, we are temporarily disabling retries.' );
 
 		$sut = new EventManager();
 
@@ -588,6 +602,8 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 	 */
 	public function test_shutdown_hiive_connection_wp_error(): void {
 
+		$this->markTestSkipped( 'Due to an unidentified bug causing events to be resent, we are temporarily disabling retries.' );
+
 		$sut = new EventManager();
 
 		$event      = Mockery::mock( Event::class )->makePartial();
@@ -633,6 +649,8 @@ class EventManagerTest extends \WP_Mock\Tools\TestCase {
 	 * @covers ::send_request_events
 	 */
 	public function test_shutdown_hiive_500_error(): void {
+
+		$this->markTestSkipped( 'Due to an unidentified bug causing events to be resent, we are temporarily disabling retries.' );
 
 		$sut = new EventManager();
 

--- a/tests/phpunit/includes/HiiveConnectionTest.php
+++ b/tests/phpunit/includes/HiiveConnectionTest.php
@@ -17,6 +17,7 @@ class HiiveConnectionTest extends TestCase {
 		parent::setUp();
 
 		WP_Mock::passthruFunction( '__' );
+		WP_Mock::passthruFunction( 'sanitize_title' );
 
 		WP_Mock::userFunction( 'wp_json_encode' )->andReturnUsing(
 			function ( $input ) {
@@ -46,8 +47,6 @@ class HiiveConnectionTest extends TestCase {
 		$plugin->expects( 'get' )->once()->with( 'version', '0' )->andReturn( '1.2.3' );
 		container()->set( 'plugin', $plugin );
 
-		WP_Mock::passthruFunction( 'sanitize_title' );
-
 		WP_Mock::userFunction( 'get_option' )->once()->with( 'newfold_cache_level', 2 )->andReturn( 2 );
 		WP_Mock::userFunction( 'get_option' )->once()->with( 'newfold_cloudflare_enabled', false )->andReturn( false );
 		WP_Mock::userFunction( 'get_option' )->once()->with( 'admin_email' )->andReturn( 'admin@example.com' );
@@ -76,8 +75,6 @@ class HiiveConnectionTest extends TestCase {
 		$plugin->expects( 'get' )->once()->with( 'id', 'error' )->andReturn( 'bluehost' );
 		$plugin->expects( 'get' )->once()->with( 'version', '0' )->andReturn( '1.2.3' );
 		container()->set( 'plugin', $plugin );
-
-		WP_Mock::passthruFunction( 'sanitize_title' );
 
 		WP_Mock::userFunction( 'get_option' )->once()->with( 'newfold_cache_level', 2 )->andReturn( 2 );
 		WP_Mock::userFunction( 'get_option' )->once()->with( 'newfold_cloudflare_enabled', false )->andReturn( false );


### PR DESCRIPTION
## Proposed changes

Too many events are being sent to Hiive.

* Stop retrying events - i.e. remove events after attempted send
* Reduce the number of events sent in a bulk request from 100 to 50
* Stop sending these events from WordPress: `page_view`, `wp_mail`, `plugin_updated`
* Add the WP brand name and plugin version to the user agent in the plugin

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

`page_view` or `pageview` ?
