### PR TITLE
Add `page_view` to disabled events

### DIFF
--- a/includes/EventManager.php
+++ b/includes/EventManager.php
@@ -122,7 +122,7 @@ class EventManager {
 	public function shutdown(): void {
 
 		// Due to a bug sending too many events, we are temporarily disabling these.
-		$disabled_events = array( 'pageview', 'wp_mail', 'plugin_updated' );
+		$disabled_events = array( 'pageview', 'page_view', 'wp_mail', 'plugin_updated' );
 		foreach ( $this->queue as $index => $event ) {
 			if ( in_array( $event->key, $disabled_events, true ) ) {
 				unset( $this->queue[ $index ] );


### PR DESCRIPTION
## Proposed changes

PR #103 included `pageview` but in retrospect, I think the correct one was `page_view`.

This suggests there is a longstanding error on this line: https://github.com/newfold-labs/wp-module-data/blob/e5c949ac106c867c6c64a83429c27d800b0d43ac/includes/EventManager.php#L135

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
