### PR TITLE
check if wp_is_serving_rest_request exists first

### DIFF
--- a/includes/HiiveConnection.php
+++ b/includes/HiiveConnection.php
@@ -318,6 +318,19 @@ class HiiveConnection implements SubscriberInterface {
 	}
 
 	/**
+	 * Get timeout value for hiive request
+	 *
+	 * @return number The timeout in seconds
+	 */
+	public function get_hiive_request_timeout() {
+		// If we're responding to the frontend, we need to be quick.
+		if ( function_exists( '\wp_is_serving_rest_request' ) && \wp_is_serving_rest_request() ) {
+			return 15;
+		}
+		return 60;
+	}
+
+	/**
 	 * Send an HTTP request to Hiive and return the body of the request.
 	 *
 	 * Handles throttling and reconnection, clients should handle queueing if necessary.
@@ -353,7 +366,7 @@ class HiiveConnection implements SubscriberInterface {
 				'Accept'        => 'application/json',
 				'Authorization' => 'Bearer ' . self::get_auth_token(),
 			),
-			'timeout' => \wp_is_serving_rest_request() ? 15 : 60, // If we're responding to the frontend, we need to be quick.
+			'timeout' => $this->get_hiive_request_timeout(),
 		);
 
 		$parsed_args = \wp_parse_args( $args ?? array(), $defaults );


### PR DESCRIPTION
move the logic into its own method to keep it readable

## Proposed changes

Still hitting a fatal error in tests where the method is undefined. This checks if it exists before attempting to use it. Since it's only used to determine the timeout, this isn't too big a deal if the method isn't defined.

I suspect it's only being called because we're spoofing a token in our test since the solutions request bails if there's no connection. But not sure why the method would be undefined in that case, this should take care of the fatal though.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
