### PR TITLE
Add Admin user data to JetPack connected event

### DIFF
--- a/includes/Listeners/Jetpack.php
+++ b/includes/Listeners/Jetpack.php
@@ -56,6 +56,7 @@ class Jetpack extends Listener {
 			array(
 				'id'     => $id,
 				'public' => $is_public,
+				'users' => array( $this, 'get_admin_users' ),
 			)
 		);
 	}
@@ -132,5 +133,32 @@ class Jetpack extends Listener {
 			! $jetpack_affiliate_code &&
 											update_option( 'jetpack_affiliate_code', $this->brand_code[ $brand ] );
 		}
+	}
+
+	/**
+	 * Get Admin and SuperAdmin user accounts
+	 *
+	 * @return $users Array of Admin & Super Admin users
+	 */
+	private function get_admin_users() {
+		// Get all admin users
+		$admin_users = get_users([
+			'role' => 'administrator',
+		]);
+		$users = [];
+
+		// Add administrators to the $users and check for super admin
+		foreach ($admin_users as $user) {
+			$users[] = [
+				'id'       => $user->ID,
+				'username' => $user->user_login,
+				'email'    => $user->user_email,
+				'name'     => $user->display_name,
+				'roles'    => $user->roles,
+				'super_admin' => is_super_admin($user->ID),
+			];
+		}
+
+		return $users;
 	}
 }


### PR DESCRIPTION
## Proposed changes

This pull request adds `users` data (array of administrator users for the WordPress site) data to Jetpack connected event.

```
[
    {
        "id": 1,
        "username": "admin",
        "email": "admin@example.com",
        "name": "Admin User",
        "roles": ["administrator"],
        "super_admin": true
    }
]
```