### PR TITLE
Add created_at timestamp to the Events

### DIFF
--- a/includes/Event.php
+++ b/includes/Event.php
@@ -50,6 +50,13 @@ class Event {
 	public $time;
 
 	/**
+	 * DateTime when the event occurred
+	 *
+	 * @var string
+	 */
+	public $created_at;
+
+	/**
 	 * Construct
 	 *
 	 * @param string $category General category of the event. Should match to a Listener class
@@ -60,7 +67,8 @@ class Event {
 		global $title;
 
 		// Event details
-		$this->time     = time();
+		$this->time     = time(); // TODO: Remove this if not used anywhere
+		$this->created_at  = current_time( 'mysql' );
 		$this->category = strtolower( $category );
 		$this->key      = $key;
 		$this->data     = $data;

--- a/includes/Event.php
+++ b/includes/Event.php
@@ -43,13 +43,6 @@ class Event {
 	public $user;
 
 	/**
-	 * Timestamp when the event occurred
-	 *
-	 * @var integer
-	 */
-	public $time;
-
-	/**
 	 * DateTime when the event occurred
 	 *
 	 * @var string
@@ -67,7 +60,6 @@ class Event {
 		global $title;
 
 		// Event details
-		$this->time     = time(); // TODO: Remove this if not used anywhere
 		$this->created_at  = current_time( 'mysql' );
 		$this->category = strtolower( $category );
 		$this->key      = $key;

--- a/includes/Event.php
+++ b/includes/Event.php
@@ -60,7 +60,7 @@ class Event {
 		global $title;
 
 		// Event details
-		$this->created_at  = current_time( 'mysql' );
+		$this->created_at  = date( 'Y-m-d H:i:s.u' );
 		$this->category = strtolower( $category );
 		$this->key      = $key;
 		$this->data     = $data;

--- a/includes/EventQueue/Queues/BatchQueue.php
+++ b/includes/EventQueue/Queues/BatchQueue.php
@@ -74,7 +74,11 @@ class BatchQueue implements BatchQueueInterface {
 
 		foreach ( $rawEvents as $rawEvent ) {
 			if ( property_exists( $rawEvent, 'id' ) && property_exists( $rawEvent, 'event' ) ) {
-				$events[ $rawEvent->id ] = maybe_unserialize( $rawEvent->event );
+				$eventData = maybe_unserialize( $rawEvent->event );
+				if ( is_array( $eventData ) && property_exists( $rawEvent, 'created_at' ) ) {
+					$eventData['created_at'] = $rawEvent->created_at;
+				}
+				$events[ $rawEvent->id ] = $eventData;
 			}
 		}
 


### PR DESCRIPTION
## Proposed changes

Updated the event payload in the WordPress data module to include the created_at timestamp when sending batched events to Hiive. This timestamp, already present in the event data table, is now added to the payload to ensure accurate event timestamping. For non-batched events, the created_at field is added dynamically during event processing.

Jira Ticket: https://jira.newfold.com/browse/PRESS11-56