### PR TITLE
fix(transient): prevent PHP notices by ensuring valid array structure

### DIFF
--- a/includes/Helpers/Transient.php
+++ b/includes/Helpers/Transient.php
@@ -54,7 +54,13 @@ class Transient {
 				\delete_option( $key );
 				$value = false;
 			}
-		}
+		} else {
+			/**
+			 * Set $value to false if $data is not a valid array.
+			 * This is to prevent PHP notices when trying to access $data['expires_at'].
+			 */
+			$value = false;
+        }
 
 		/**
 		 * Implement the filters as used in {@see get_transient()}.


### PR DESCRIPTION
## Proposed changes

Modification
The modification adds a check to ensure that the value returned by the get_option($key) function is a valid array containing the expires_at and value keys. If the value is not a valid array, the $value variable is set to false to prevent PHP notices when trying to access non-existent keys.

Motivation
The motivation behind this modification is to prevent potential PHP notices that could occur when trying to access the expires_at key in a value that is not a valid array. This improves the robustness of the code by ensuring it correctly handles unexpected or corrupted data in the database.

## Type of Change

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

I was creating a WordPress site and the plugin used by HostGator caused a 'fatal error' when I installed some plugins. The error log indicated an undefined variable error pointing to the file and line 62. Upon inspecting the file, I noticed that the variable could be set without being a valid array, and this was not being checked. By adding an else statement to set the variable to false if the array was not valid, the issue was resolved and my site went back online normally.

error_log message:

[21-Jan-2025 04:19:21 UTC] PHP Warning: Undefined variable $value in /home1/focoe886/public_html/wp-content/plugins/wp-plugin-hostgator/vendor/newfold-labs/wp-module-data/includes/Helpers/Transient.php on line 62

![image](https://github.com/user-attachments/assets/2a51cacc-961a-4aef-9282-734bd3401ee7)

Modification made in the Transient.php file on my WordPress site:

![image](https://github.com/user-attachments/assets/19f4a7aa-a4f4-47a6-93d8-80bc78f304a2)

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

The contribution guidelines state that if tests have not been performed, an explanation should be provided. I did not create tests for this PR modification because I tested it directly on my site, and it worked perfectly, stopping the error_log message and the fatal error when accessing wp-admin. Additionally, it is a simple one-line modification that can be easily verified.

I am not a PHP developer, I did not have Composer installed to run the tests, and to save time, I decided to submit without tests since it is just an additional else statement.

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ x ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->