### PR TITLE
Use pre_update_option hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.phpunit.cache
+.phpunit.result.cache
 .DS_Store
 /node_modules
 /tests/_output

--- a/includes/Listeners/Commerce.php
+++ b/includes/Listeners/Commerce.php
@@ -360,19 +360,35 @@ class Commerce extends Listener {
 	 */
 	public function woopay_connection($new_option, $old_option): array
 	{
+
+		// If the option has not changed, bail
+		if ($new_option === $old_option) {
+			return $new_option;
+		}
+
+		// If the option is empty, or the status is not set, bail
+		if (empty($new_option) || ! isset($new_option['data']['status'])) {
+			return $new_option;
+		}
+
+		// If the status is not changing, bail
+		if (isset($old_option['data']['status']) && ($new_option['data']['status'] === $old_option['data']['status'])) {
+			return $new_option;
+		}
+
 		$url  = is_ssl() ? 'https://' : 'http://';
 		$url .= $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-		$data = array(
-			'label_key' => 'provider',
-			'provider'  => 'woopay',
-			'page'      => $url,
+
+		$this->push(
+			'payment_connected',
+			array(
+				'label_key' => 'provider',
+				'provider'  => 'woopay',
+				'status'    => $new_option['data']['status'],
+				'page'      => $url,
+			)
 		);
-		if ( empty( $old_option ) && ! empty( $new_option ) ) {
-			$this->push(
-				'payment_connected',
-				$data
-			);
-		}
+
 		return $new_option;
 	}
 }

--- a/includes/Listeners/Commerce.php
+++ b/includes/Listeners/Commerce.php
@@ -28,7 +28,7 @@ class Commerce extends Listener {
 		add_filter( 'woocommerce_update_product', array( $this, 'product_created_or_updated' ), 100, 2 );
 		add_action( 'update_option_woocommerce_custom_orders_table_enabled', array( $this, 'woocommerce_hpos_enabled' ), 10, 3 );
 		// Hook into the update of the 'wcpay_account_data' option to trigger an event when WooPay is connected.
-		add_filter( 'update_option_wcpay_account_data', array( $this, 'woopay_connection' ), 10, 2 );
+		add_filter('pre_update_option_wcpay_account_data', array($this, 'woopay_connection'), 10, 2);
 	}
 
 	/**

--- a/includes/Listeners/Commerce.php
+++ b/includes/Listeners/Commerce.php
@@ -358,7 +358,8 @@ class Commerce extends Listener {
 	 * @param array{data:array{account_id:string,status:string,last_updated:string}} $new_option  New value of the woopay connection option
 	 * @param array|false|string                                                     $old_option  Old value of the woopay connection option
 	 */
-	public function woopay_connection( $new_option, $old_option ): void {
+	public function woopay_connection($new_option, $old_option): array
+	{
 		$url  = is_ssl() ? 'https://' : 'http://';
 		$url .= $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 		$data = array(
@@ -372,5 +373,6 @@ class Commerce extends Listener {
 				$data
 			);
 		}
+		return $new_option;
 	}
 }

--- a/tests/phpunit/includes/Listeners/CommerceTest.php
+++ b/tests/phpunit/includes/Listeners/CommerceTest.php
@@ -70,12 +70,14 @@ class CommerceTest extends \WP_Mock\Tools\TestCase {
 	public function test_woopay_connection(): void {
 
 		WP_Mock::userFunction( 'is_ssl' )->once()->andReturnTrue();
+		WP_Mock::userFunction( 'get_current_user_id' )->once()->andReturn( 1 );
 		$_SERVER['HTTP_HOST']   = 'example.com/';
 		$_SERVER['REQUEST_URI'] = 'subdir';
 
 		$expected_data_array = array(
 			'label_key' => 'provider',
 			'provider'  => 'woopay',
+			'status'    => 'connected',
 			'page'      => 'https://example.com/subdir',
 		);
 

--- a/tests/phpunit/includes/Listeners/CommerceTest.php
+++ b/tests/phpunit/includes/Listeners/CommerceTest.php
@@ -16,6 +16,8 @@ class CommerceTest extends \WP_Mock\Tools\TestCase {
 	public function setUp(): void {
 		parent::setUp();
 		WP_Mock::setUp();
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
 	}
 
 	public function tearDown(): void {

--- a/tests/phpunit/includes/Listeners/CommerceTest.php
+++ b/tests/phpunit/includes/Listeners/CommerceTest.php
@@ -70,7 +70,6 @@ class CommerceTest extends \WP_Mock\Tools\TestCase {
 	public function test_woopay_connection(): void {
 
 		WP_Mock::userFunction( 'is_ssl' )->once()->andReturnTrue();
-		WP_Mock::userFunction( 'get_current_user_id' )->once()->andReturn( 1 );
 		$_SERVER['HTTP_HOST']   = 'example.com/';
 		$_SERVER['REQUEST_URI'] = 'subdir';
 


### PR DESCRIPTION
## Proposed changes

Existing WooPay events were not being sent. This PR uses the appropriate filter.

## Type of Change

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->