### PR TITLE
Stop sending to Hiive API admin users with null email

### DIFF
--- a/includes/Helpers/Plugin.php
+++ b/includes/Helpers/Plugin.php
@@ -106,7 +106,11 @@ class Plugin {
 		);
 		$users       = array();
 
-		// Add administrators to the $users and check for super admin
+		/**
+		 * Add administrators to the $users and check for super admin
+		 *
+		 * @var \WP_User $user
+		 */
 		foreach ( $admin_users as $user ) {
 			if ( empty( $user->user_email ) ) {
 				continue;

--- a/includes/Helpers/Plugin.php
+++ b/includes/Helpers/Plugin.php
@@ -108,6 +108,10 @@ class Plugin {
 
 		// Add administrators to the $users and check for super admin
 		foreach ( $admin_users as $user ) {
+			if ( empty( $user->user_email ) ) {
+				continue;
+			}
+
 			$users[] = array(
 				'id'    => $user->ID,
 				'email' => $user->user_email,

--- a/includes/Helpers/Plugin.php
+++ b/includes/Helpers/Plugin.php
@@ -93,9 +93,9 @@ class Plugin {
 	}
 
 	/**
-	 * Get Admin and SuperAdmin user accounts
+	 * Get Admin user accounts
 	 *
-	 * @return array<array{id:int, email:string}> $users Array of Admin & Super Admin users
+	 * @return array<array{id:int, email:string}> $users Array of Admin user.
 	 */
 	protected function get_admin_users(): array {
 		// Get all admin users
@@ -107,7 +107,7 @@ class Plugin {
 		$users       = array();
 
 		/**
-		 * Add administrators to the $users and check for super admin
+		 * Add administrators to the $users array, filtering out those with an email address.
 		 *
 		 * @var \WP_User $user
 		 */

--- a/tests/wpunit/includes/Helpers/PluginWPUnitTest.php
+++ b/tests/wpunit/includes/Helpers/PluginWPUnitTest.php
@@ -59,6 +59,26 @@ class PluginWPUnitTest extends WPUnitTestCase {
 	}
 
 	/**
+	 * @covers ::collect
+	 * @covers ::get_data
+	 * @covers ::get_admin_users
+	 */
+	public function test_collect_jetpack_filters_users_with_no_email(): void {
+		$username    = uniqid( 'admin' );
+		$new_user_id = wp_create_user( $username, 'password', "{$username}@example.com" );
+		$new_user    = new \WP_User( $new_user_id );
+		$new_user->add_role( 'administrator' );
+		$new_user->user_email = ''; // Remove email to test filtering
+		wp_update_user( $new_user );
+
+		$sut = new Plugin();
+
+		$result = $sut->collect( 'jetpack/jetpack.php' );
+
+		$this->assertCount( 1, $result['users'] );
+	}
+
+	/**
 	 * @covers ::collect_installed
 	 */
 	public function test_collect_installed(): void {


### PR DESCRIPTION
## Proposed changes 🔥

We see an increased amount of events handling errors on Hiive, due to users with `null` email being sent together with jetpack activation events
[PR-808](https://github.com/newfold-labs/laravel-hiive/pull/808) was opened on Hiive to fix the problem on that side.
Anyway, it would be nice to stop sending null emails completely; this PR aims to do so.

[Reference](https://jira.newfold.com/browse/PRESS11-240) to original JIRA issue

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Not sure how a site may have an administrator user with `null` email, but that's exactly what we see on Hiive records
It may be worth to investigate the origin of this error