### PR TITLE
Add initial docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,6 @@ composer run test-coverage
 
 ## Keeping documentation current
 
-**When you change code, features, or workflows, update the docs so they stay accurate.**
+**When you change code, features, or workflows, update the docs so they stay accurate.** Keep **docs/index.md** current: when you add, remove, or rename doc files, update the table of contents (and quick links if present).
 
 - Keep all docs current. When adding or changing dependencies, update **dependencies.md**. When cutting a release, update **docs/changelog.md**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Agent guidance – wp-module-data
+
+This file gives AI agents a quick orientation to the repo. For full detail, see the **docs/** directory.
+
+## What this project is
+
+- **wp-module-data** – Newfold Data Module: shared data, telemetry, and site capabilities for Newfold WordPress brand plugins. It registers with the loader as the `data` module (hidden), provides `SiteCapabilities` to the container (used by runtime and other modules), manages an event queue and Hiive connection, and runs versioned upgrades. Maintained by Newfold Labs.
+
+- **Stack:** PHP 7.4+, `ext-json`. Depends on wp-module-context, wp-module-loader, wp-forge/helpers, wp-forge/wp-query-builder, wp-forge/wp-upgrade-handler, wpscholar/url.
+
+- **Architecture:** Registers on `plugins_loaded` via the loader; on `newfold_container_set` it registers activation/deactivation hooks and sets `capabilities` in the container (SiteCapabilities instance). Data module starts Hiive connection and event manager; capabilities are cached in transients.
+
+## Key paths
+
+| Purpose | Location |
+|---------|----------|
+| Bootstrap & registration | `bootstrap.php` – version, upgrades, register module, container set, filters |
+| Main module logic | `includes/Data.php` – start(), Hiive, EventManager |
+| Site capabilities | `includes/SiteCapabilities.php` – get/all, transient cache |
+| Event queue / Hiive | `includes/Event.php`, `EventManager.php`, `HiiveConnection.php`, `HiiveWorker.php` |
+| Upgrades | `upgrades/` |
+| Tests | `tests/` (PHPUnit, Codeception wpunit) |
+
+## Essential commands
+
+```bash
+composer install
+composer run lint
+composer run fix
+composer run test
+composer run test-coverage
+```
+
+## Documentation
+
+- **Full documentation** is in **docs/**. Start with **docs/index.md**.
+- **CLAUDE.md** is a symlink to this file (AGENTS.md).
+
+---
+
+## Keeping documentation current
+
+**When you change code, features, or workflows, update the docs so they stay accurate.**
+
+- Keep all docs current. When adding or changing dependencies, update **dependencies.md**. When cutting a release, update **docs/changelog.md**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-data
+title: Dependencies
+description: Composer and npm dependencies.
+updated: 2025-03-18
+---
+
 # Dependencies
 
 ## Runtime

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,23 @@
+# Dependencies
+
+## Runtime
+
+| Package | Purpose |
+|---------|---------|
+| **ext-json** | JSON encoding/decoding for API and data handling. |
+| **newfold-labs/wp-module-context** | Context (brand, platform) for API and behavior. |
+| **newfold-labs/wp-module-loader** | Module registration and container; module is registered with the loader. |
+| **wp-forge/helpers** | Helper functions (e.g. dataGet) used in Data and elsewhere. |
+| **wp-forge/wp-query-builder** | Query building for database operations (e.g. event queue). |
+| **wp-forge/wp-upgrade-handler** | Versioned upgrade runs in `upgrades/`; stores version in option `nfd_data_module_version`. |
+| **wpscholar/url** | URL handling (e.g. for Hiive or API URLs). |
+
+## Dev
+
+- **johnpbloch/wordpress** – WordPress core for tests.
+- **lucatume/wp-browser** – Codeception and WPUnit.
+- **newfold-labs/wp-php-standards** – PHPCS.
+- **phpunit/phpcov** – Coverage.
+- **10up/wp_mock** – PHPUnit mocks.
+- **kporras07/composer-symlinks** – Symlinks for wp-content/plugins/wp-module-data (dev convenience).
+- Optional: **newfold-labs/wp-plugin-bluehost** (zip), **wpackagist-plugin/jetpack**, **woocommerce**, etc. for integration tests.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-data
+title: Development
+description: Lint, test, and workflow.
+updated: 2025-03-18
+---
+
 # Development
 
 ## Linting

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,17 @@
+# Development
+
+## Linting
+
+- **PHP:** `composer run lint` (PHPCS), `composer run fix` (PHPCBF). Uses `phpcs.xml` and `newfold-labs/wp-php-standards`.
+
+## Testing
+
+- **PHPUnit + Codeception:** `composer run test` runs PHPUnit and Codeception wpunit.
+- **Coverage:** `composer run test-coverage`; then open `tests/_output/html/index.html`.
+
+## Day-to-day workflow
+
+1. Make changes in `includes/` or `bootstrap.php` or `upgrades/`.
+2. Run `composer run lint` and `composer run test` before committing.
+3. When adding or changing the container contract (e.g. capabilities) or hooks, update [integration.md](integration.md) and [overview.md](overview.md).
+4. When cutting a release, update **docs/changelog.md** and bump `NFD_DATA_MODULE_VERSION` in `bootstrap.php`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-data
+title: Getting started
+description: Prerequisites, install, and run.
+updated: 2025-03-18
+---
+
 # Getting started
 
 ## Prerequisites

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,46 @@
+# Getting started
+
+## Prerequisites
+
+- **PHP** 7.4+ with **ext-json** (see `composer.json`).
+- **Composer** for dependencies.
+- **WordPress** (module runs inside a host plugin).
+
+## Install
+
+From the package root:
+
+```bash
+composer install
+```
+
+Pulls in wp-module-context, wp-module-loader, wp-forge packages, and wpscholar/url. Dev dependencies include WordPress, PHPUnit, Codeception, and optional Bluehost plugin zip for tests.
+
+## Run tests
+
+```bash
+composer run test
+```
+
+Runs PHPUnit and Codeception wpunit. For coverage:
+
+```bash
+composer run test-coverage
+```
+
+Then open `tests/_output/html/index.html` to view the report.
+
+## Lint and fix
+
+```bash
+composer run lint
+composer run fix
+```
+
+## Using in a host plugin
+
+1. Depend on `newfold-labs/wp-module-data` via Composer.
+2. Ensure the loader and container are set before `plugins_loaded` (the data module registers on `plugins_loaded`).
+3. On `newfold_container_set`, the module registers `capabilities` in the container and activation/deactivation hooks. The runtime and other modules use `container()->get( 'capabilities' )` to read site capabilities.
+
+See [integration.md](integration.md) for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Documentation for wp-module-data (Newfold Data Module), for **humans** and **AI 
 | [integration.md](integration.md) | How the module registers, provides capabilities, and integrates with the container. |
 | [development.md](development.md) | Lint, test, and day-to-day workflow. |
 | [dependencies.md](dependencies.md) | Composer dependencies and how they are used. |
+| [release.md](release.md) | Release process: use the Newfold Prepare Release workflow. |
 
 ## Quick links
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-data
+title: Documentation index
+description: Table of contents and quick links.
+updated: 2025-03-18
+---
+
 # wp-module-data – Documentation index
 
 Documentation for wp-module-data (Newfold Data Module), for **humans** and **AI agents**. Start here.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,20 @@
+# wp-module-data – Documentation index
+
+Documentation for wp-module-data (Newfold Data Module), for **humans** and **AI agents**. Start here.
+
+## Table of contents
+
+| Document | Description |
+|----------|-------------|
+| [overview.md](overview.md) | What the module does, who maintains it, and high-level behavior. |
+| [getting-started.md](getting-started.md) | Prerequisites, install, and how to run tests. |
+| [integration.md](integration.md) | How the module registers, provides capabilities, and integrates with the container. |
+| [development.md](development.md) | Lint, test, and day-to-day workflow. |
+| [dependencies.md](dependencies.md) | Composer dependencies and how they are used. |
+
+## Quick links
+
+- **New to the repo:** [overview.md](overview.md) then [getting-started.md](getting-started.md).
+- **Integrating with the container or capabilities:** [integration.md](integration.md).
+
+Root **AGENTS.md** gives a short agent summary and points here.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,45 @@
+# Integration
+
+## How the module registers
+
+The data module registers with the Newfold Module Loader on `plugins_loaded`:
+
+- **name:** `data`
+- **label:** Data (translatable)
+- **callback:** Instantiates `Data` with `container()->plugin()` and calls `$module->start()`.
+- **isActive:** true
+- **isHidden:** true
+
+So it does not appear in the UI as a toggleable module; it always runs when the loader loads active modules.
+
+## Container: capabilities
+
+On the action `newfold_container_set`, the bootstrap registers in the container:
+
+```php
+$container->set( 'capabilities', $container->service( function () {
+    return new SiteCapabilities();
+} ) );
+```
+
+So `container()->get( 'capabilities' )` returns a `SiteCapabilities` instance. That class:
+
+- Caches capabilities in a transient (e.g. `nfd_site_capabilities`).
+- Exposes `all()` (array of capability name => bool) and `get( $capability )` (bool).
+- Is used by wp-module-runtime (for `window.NewfoldRuntime.capabilities`) and by other modules (e.g. AI, ECommerce, HelpCenter, Onboarding) to gate features.
+
+## Activation and deactivation
+
+The bootstrap registers activation and deactivation hooks on the plugin file (from the container’s plugin instance):
+
+- **Activation:** Create the event queue table (`nfd_create_event_queue_table`) and set a transient to signal plugin activation.
+- **Deactivation:** Delete the data module version option and drop the event queue table.
+
+## Filters
+
+- **pre_update_option_nfd_data_token** / **option_nfd_data_token** – Encrypt on save, decrypt on read (via `Encryption` helper).
+- **pre_set_transient_nfd_site_capabilities** – Optional override for capabilities (e.g. default for bluehost brand when transient is empty).
+
+## Event queue and Hiive
+
+The `Data` class starts a Hiive connection and event manager. Events can be queued and sent to Hiive; see `EventManager`, `HiiveConnection`, and `HiiveWorker` for implementation details.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-data
+title: Integration
+description: How the module registers and integrates.
+updated: 2025-03-18
+---
+
 # Integration
 
 ## How the module registers

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,21 @@
+# Overview
+
+## What the module does
+
+**wp-module-data** (Newfold Data Module) provides shared data and telemetry for Newfold WordPress brand plugins. It:
+
+- **Registers** with the Newfold Module Loader as the `data` module (hidden). Its callback receives the container’s plugin instance and starts the Data module (Hiive connection, event manager).
+- **Provides capabilities** – On `newfold_container_set`, it registers `capabilities` in the container as a `SiteCapabilities` instance. That object fetches and caches site capabilities (e.g. from Hiive or defaults), and exposes `all()` and `get( $capability )` so the runtime and other modules can gate features.
+- **Event queue** – Maintains an event queue table and Hiive worker for sending events.
+- **Upgrades** – Uses `WP_Forge\UpgradeHandler` with version `NFD_DATA_MODULE_VERSION` and upgrade scripts in `upgrades/`.
+- **Token encryption** – Filters for `nfd_data_token` option encrypt on save and decrypt on read.
+
+## Who maintains it
+
+- **Newfold Labs** (Newfold Digital). Distributed via Newfold Satis and used by all Newfold WordPress brand plugins.
+
+## High-level features
+
+- Site capabilities (cached in transient `nfd_site_capabilities` or similar).
+- Hiive connection and event queue.
+- Activation/deactivation hooks to create/drop the event queue table and set/clear version.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-data
+title: Overview
+description: What the module does and who maintains it.
+updated: 2025-03-18
+---
+
 # Overview
 
 ## What the module does

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,26 @@
+# Release process
+
+This module follows the standard Newfold release process using a reusable workflow.
+
+## Prepare release (recommended)
+
+1. **Run the Newfold Prepare Release workflow**
+   - In GitHub: **Actions** → **Newfold Prepare Release** → **Run workflow**.
+   - Choose the version **level**: `patch`, `minor`, or `major`.
+   - The workflow will:
+     - Bump the version to the chosen level (in the appropriate files, e.g. `composer.json`, plugin header, or `package.json`).
+     - Run a fresh build if the module has frontend assets.
+     - Update language files (i18n).
+     - Open a pull request with the changes.
+
+2. **Review and merge** the prep-release PR.
+
+3. **Tag and publish** the release (e.g. create a GitHub release from the tag, or follow your team's process for Satis/packagist).
+
+## Manual release (fallback)
+
+If the workflow is unavailable, bump the version manually in the same places the workflow would (see `.github/workflows/newfold-prep-release.yml` inputs for `json-file` and `php-file`), run any build and i18n commands, then tag and release. Prefer using the workflow when possible for consistency.
+
+## After each release
+
+- Update **docs/changelog.md** with the changes in the release.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,21 @@
+---
+name: wp-module-data
+title: Release process
+description: Release process and version bump.
+updated: 2025-03-18
+---
+
 # Release process
 
 This module follows the standard Newfold release process using a reusable workflow.
+
+## Build step required
+
+See `.github/workflows/newfold-prep-release.yml`: the workflow uses `json-file` and `php-file` inputs. If this module has a frontend (e.g. `package.json` has a `build` script), run `npm run build` before tagging; the workflow runs it automatically. Otherwise no build step is required.
+
+## Hardcoded versions to bump
+
+The workflow bumps the version in the files specified in `.github/workflows/newfold-prep-release.yml` (`json-file` and `php-file`—typically **bootstrap.php** for the PHP version constant (e.g. `NFD_*_MODULE_VERSION`) and **package.json** for the `version` field). If releasing manually, update those files, run any build and i18n commands, then tag and release.
 
 ## Prepare release (recommended)
 


### PR DESCRIPTION
Adds AGENTS.md, CLAUDE.md (symlink to AGENTS.md), and docs/ per the Newfold modules documentation rollout: overview, getting-started, integration, development, and dependencies where applicable.

Made with [Cursor](https://cursor.com)