### PR TITLE
Improve site capabilities fetching

### DIFF
--- a/includes/SiteCapabilities.php
+++ b/includes/SiteCapabilities.php
@@ -22,12 +22,21 @@ class SiteCapabilities {
 	protected $transient;
 
 	/**
+	 * Hiive connection manager
+	 *
+	 * @var HiiveConnection
+	 */
+	protected $hiive;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param ?Transient $transient Inject instance of Transient class.
+	 * @param ?HiiveConnection $hiive Inject instance of the hiive connection manager
 	 */
-	public function __construct( ?Transient $transient = null ) {
+	public function __construct( ?Transient $transient = null, ?HiiveConnection $hiive = null ) {
 		$this->transient = $transient ?? new Transient();
+		$this->hiive     = $hiive ?? new HiiveConnection();
 	}
 
 	/**
@@ -114,14 +123,10 @@ class SiteCapabilities {
 	protected function fetch(): array {
 		$capabilities = array();
 
-		$response = wp_remote_get(
-			constant( 'NFD_HIIVE_URL' ) . '/sites/v1/capabilities',
-			array(
-				'headers' => array(
-					'Content-Type'  => 'application/json',
-					'Accept'        => 'application/json',
-					'Authorization' => 'Bearer ' . HiiveConnection::get_auth_token(),
-				),
+		$response = $this->hiive->hiive_request(
+			'sites/v1/capabilities',
+			args: array(
+				'method' => 'GET'
 			)
 		);
 

--- a/includes/SiteCapabilities.php
+++ b/includes/SiteCapabilities.php
@@ -126,7 +126,7 @@ class SiteCapabilities {
 			'sites/v1/capabilities',
 			null,
 			array(
-				'method' => 'GET'
+				'method' => 'GET',
 			)
 		);
 

--- a/includes/SiteCapabilities.php
+++ b/includes/SiteCapabilities.php
@@ -32,7 +32,7 @@ class SiteCapabilities {
 	 * Constructor.
 	 *
 	 * @param ?Transient $transient Inject instance of Transient class.
-	 * @param ?HiiveConnection $hiive Inject instance of the hiive connection manager
+	 * @param ?HiiveConnection $hiive Inject instance of the hiive connection manager.
 	 */
 	public function __construct( ?Transient $transient = null, ?HiiveConnection $hiive = null ) {
 		$this->transient = $transient ?? new Transient();
@@ -60,7 +60,7 @@ class SiteCapabilities {
 	 *
 	 * @used-by Capabilities::update()
 	 *
-	 * @param array<string, bool> $capabilities
+	 * @param array<string, bool> $capabilities The capabilities array.
 	 *
 	 * @return bool True if the value was changed, false otherwise.
 	 */
@@ -75,7 +75,7 @@ class SiteCapabilities {
 	 * @used-by self::fetch()
 	 * @used-by Capabilities::update()
 	 *
-	 * @param array<string, bool> $capabilities
+	 * @param array<string, bool> $capabilities The capabilities array.
 	 *
 	 * @return bool True if the value was set, false otherwise.
 	 */
@@ -124,7 +124,8 @@ class SiteCapabilities {
 
 		$response = $this->hiive->hiive_request(
 			'sites/v1/capabilities',
-			args: array(
+			null,
+			array(
 				'method' => 'GET'
 			)
 		);

--- a/includes/SiteCapabilities.php
+++ b/includes/SiteCapabilities.php
@@ -121,7 +121,6 @@ class SiteCapabilities {
 	 * @return array<string, bool>
 	 */
 	protected function fetch(): array {
-		$capabilities = array();
 
 		$response = $this->hiive->hiive_request(
 			'sites/v1/capabilities',
@@ -130,14 +129,13 @@ class SiteCapabilities {
 			)
 		);
 
-		if ( wp_remote_retrieve_response_code( $response ) === 200 && ! is_wp_error( $response ) ) {
-			$body = wp_remote_retrieve_body( $response );
-			$data = json_decode( $body, true );
-			if ( $data && is_array( $data ) ) {
-				$capabilities = $data;
-			}
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return array();
 		}
 
-		return $capabilities;
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+
+		return is_array( $data ) ? $data : array();
 	}
 }

--- a/tests/wpunit/includes/SiteCapabilitiesWPUnitTest.php
+++ b/tests/wpunit/includes/SiteCapabilitiesWPUnitTest.php
@@ -14,24 +14,6 @@ use WP_Error;
  */
 class SiteCapabilitiesWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase {
 
-	protected function setUp(): void {
-		parent::setUp();
-
-		require_once codecept_root_dir( 'vendor/antecedent/patchwork/Patchwork.php' );
-
-		\Patchwork\redefine(
-			'constant',
-			function ( string $constant_name ) {
-				switch ( $constant_name ) {
-					case 'NFD_HIIVE_URL':
-						return 'https://hiive.localhost';
-					default:
-						return \Patchwork\relay( func_get_args() );
-				}
-			}
-		);
-	}
-
 	protected function tearDown(): void {
 		parent::tearDown();
 		Mockery::resetContainer();
@@ -71,17 +53,11 @@ class SiteCapabilitiesWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase
 			->with( 'nfd_site_capabilities' )
 			->andReturnFalse();
 
-		/**
-		 * @see \WP_Http::request()
-		 */
-		add_filter(
-			'pre_http_request',
-			function () {
-				return array(
-					'body'     => json_encode( array( 'test_capability' => true ) ),
-					'response' => array( 'code' => 200 ),
-				);
-			}
+		$hiive = $this->mock_hiive_capabilities_request(
+			array(
+				'body'     => wp_json_encode( array( 'test_capability' => true ) ),
+				'response' => array( 'code' => 200 ),
+			)
 		);
 
 		$transient->shouldReceive( 'set' )
@@ -93,7 +69,7 @@ class SiteCapabilitiesWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase
 					)
 					->andReturnTrue();
 
-		$sut = new SiteCapabilities( $transient );
+		$sut = new SiteCapabilities( $transient, $hiive );
 
 		$result = $sut->get( 'test_capability' );
 
@@ -113,14 +89,8 @@ class SiteCapabilitiesWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase
 			->with( 'nfd_site_capabilities' )
 			->andReturnFalse();
 
-		/**
-		 * @see \WP_Http::request()
-		 */
-		add_filter(
-			'pre_http_request',
-			function () {
-				return new WP_Error( 'could_not_connect', 'Could not connect to Hiive' );
-			}
+		$hiive = $this->mock_hiive_capabilities_request(
+			new WP_Error( 'could_not_connect', 'Could not connect to Hiive' )
 		);
 
 		$transient->shouldReceive( 'set' )
@@ -132,7 +102,7 @@ class SiteCapabilitiesWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase
 					)
 					->andReturnTrue();
 
-		$sut = new SiteCapabilities( $transient );
+		$sut = new SiteCapabilities( $transient, $hiive );
 
 		$result = $sut->get( 'test_capability' );
 
@@ -152,17 +122,11 @@ class SiteCapabilitiesWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase
 			->with( 'nfd_site_capabilities' )
 			->andReturnFalse();
 
-		/**
-		 * @see \WP_Http::request()
-		 */
-		add_filter(
-			'pre_http_request',
-			function () {
-				return array(
-					'body'     => '',
-					'response' => array( 'code' => 401 ),
-				);
-			}
+		$hiive = $this->mock_hiive_capabilities_request(
+			array(
+				'body'     => '',
+				'response' => array( 'code' => 401 ),
+			)
 		);
 
 		$transient->shouldReceive( 'set' )
@@ -174,7 +138,7 @@ class SiteCapabilitiesWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase
 					)
 					->andReturnTrue();
 
-		$sut = new SiteCapabilities( $transient );
+		$sut = new SiteCapabilities( $transient, $hiive );
 
 		$result = $sut->get( 'test_capability' );
 
@@ -268,5 +232,27 @@ class SiteCapabilitiesWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase
 
 		$this->assertIsArray( $result );
 		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * @param array<string, mixed>|WP_Error $response
+	 *
+	 * @return HiiveConnection
+	 */
+	private function mock_hiive_capabilities_request( $response ): HiiveConnection {
+		$hiive = Mockery::mock( HiiveConnection::class );
+
+		$hiive->shouldReceive( 'hiive_request' )
+			->once()
+			->with(
+				'sites/v1/capabilities',
+				null,
+				array(
+					'method' => 'GET',
+				)
+			)
+			->andReturn( $response );
+
+		return $hiive;
 	}
 }


### PR DESCRIPTION
## Proposed changes

Use `HiiveController::hiive_request()`  to handle capability fetches and ensure a valid connection exists between the site and Hiive. This will prevent multiple 401 responses from the Hiive API.

Based on Cloudflare analytics, this should reduce requests by approximately 350K every 24 hours.

Related ticket: https://newfold.atlassian.net/browse/PRESS0-4401 

## Type of Change

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
