### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,15 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    permissions:
+      contents: write      # Required for the reusable translations workflow to push the auto-translate branch and commits.
+      pull-requests: write # Required for gh pr list/update/create flows inside the reusable workflow (GITHUB_TOKEN).
     with:
       text_domain: 'wp-module-data'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -20,10 +20,10 @@ jobs:
   translate:
     name: 'Check and update translations'
     timeout-minutes: 120
-    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     permissions:
       contents: write      # Required for the reusable translations workflow to push the auto-translate branch and commits.
       pull-requests: write # Required for gh pr list/update/create flows inside the reusable workflow (GITHUB_TOKEN).
+    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     with:
       text_domain: 'wp-module-data'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -19,6 +19,7 @@ permissions: {}
 jobs:
   translate:
     name: 'Check and update translations'
+    timeout-minutes: 120
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     permissions:
       contents: write      # Required for the reusable translations workflow to push the auto-translate branch and commits.

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -33,9 +33,9 @@ jobs:
     name: Bluehost Build and Test Playwright
     needs: setup
     timeout-minutes: 120
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone this module and the brand plugin (GITHUB_TOKEN).
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -46,9 +46,9 @@ jobs:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
     timeout-minutes: 120
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone this module and the brand plugin (GITHUB_TOKEN).
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,19 +6,19 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {} # No checkout or GitHub API usage; only derives the branch name from workflow ref env vars.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -31,9 +31,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for the reusable workflow to clone this module and the brand plugin (GITHUB_TOKEN).
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -43,9 +43,9 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for the reusable workflow to clone this module and the brand plugin (GITHUB_TOKEN).
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -18,6 +18,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions: {} # No checkout or GitHub API usage; only derives the branch name from workflow ref env vars.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
@@ -31,6 +32,7 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
+    timeout-minutes: 120
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone this module and the brand plugin (GITHUB_TOKEN).
@@ -43,6 +45,7 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
+    timeout-minutes: 120
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone this module and the brand plugin (GITHUB_TOKEN).

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write # Required to checkout the repo and push PHPCBF fixes on main via git-auto-commit-action (github.token).
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to checkout the repo and push PHPCBF fixes on main via git-auto-commit-action (github.token).
     steps:
 
       - name: Checkout

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -21,6 +21,7 @@ jobs:
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
+    timeout-minutes: 60
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     permissions:
       contents: write      # Required for the reusable prep-release workflow to push the release branch and file bumps.

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -21,10 +21,10 @@ jobs:
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
+    permissions:
+      contents: write      # Required for the reusable prep-release workflow to push the release branch and file bumps.
+      pull-requests: write # Required for gh pr list and opening the release pull request (GITHUB_TOKEN in reusable job).
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -22,10 +22,10 @@ jobs:
   prep-release:
     name: Prepare Release
     timeout-minutes: 60
-    uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     permissions:
       contents: write      # Required for the reusable prep-release workflow to push the release branch and file bumps.
       pull-requests: write # Required for gh pr list and opening the release pull request (GITHUB_TOKEN in reusable job).
+    uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -16,6 +16,7 @@ jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read # Required to checkout the repository (actions/checkout with GITHUB_TOKEN).
     steps:

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -8,10 +8,16 @@ on:
 env:
   VERSION: ${GITHUB_REF#refs/tags/*}
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the repository (actions/checkout with GITHUB_TOKEN).
     steps:
 
       - name: Checkout

--- a/.github/workflows/unit-tests-and-coverage-report.yml
+++ b/.github/workflows/unit-tests-and-coverage-report.yml
@@ -25,6 +25,7 @@ permissions: {}
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions: {} # No checkout or GitHub API usage; only derives the repo name from github.repository.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
@@ -37,6 +38,7 @@ jobs:
 
   unit-tests:
     needs: get-repo-name
+    timeout-minutes: 120
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     permissions:
       contents: write      # Required for the reusable codecoverage workflow to push coverage HTML to gh-pages.

--- a/.github/workflows/unit-tests-and-coverage-report.yml
+++ b/.github/workflows/unit-tests-and-coverage-report.yml
@@ -18,9 +18,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.head_ref) || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {} # No checkout or GitHub API usage; only derives the repo name from github.repository.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -32,10 +37,10 @@ jobs:
 
   unit-tests:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write      # Required for the reusable codecoverage workflow to push coverage HTML to gh-pages.
+      pull-requests: write # Required for the reusable workflow to add PR comments (coverage via mshick/add-pr-comment).
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/unit-tests-and-coverage-report.yml
+++ b/.github/workflows/unit-tests-and-coverage-report.yml
@@ -39,10 +39,10 @@ jobs:
   unit-tests:
     needs: get-repo-name
     timeout-minutes: 120
-    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     permissions:
       contents: write      # Required for the reusable codecoverage workflow to push coverage HTML to gh-pages.
       pull-requests: write # Required for the reusable workflow to add PR comments (coverage via mshick/add-pr-comment).
+    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3"]'
       coverage-php-version: '7.4'


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/newfold-labs/wp-module-data/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 6 (`auto-translate.yml`, `brand-plugin-test-playwright.yml`, `lint.yml`, `newfold-prep-release.yml`, `satis-webhook.yml`, `unit-tests-and-coverage-report.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `1c2fe7b6` |
| Timeouts commit | `fa2474a2` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `unit-tests-and-coverage-report.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-webhook.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` (replaced prior top-level `permissions: contents: read` and relocated the block to immediately precede `jobs:`) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `auto-translate.yml` (inserted the required two-line comment immediately above the existing `permissions: {}`) |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| unit-tests-and-coverage-report.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| satis-webhook.yml | 1 job was missing a scoped `permissions:` directive | webhook | `contents: read` [3] |
| lint.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: write` [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `brand-plugin-test-playwright.yml` :: top-level (workflow): BEFORE `permissions: contents: read` -> AFTER `# Disable permissions...` / `# Any needed...` + `permissions: {}` immediately before `jobs:` -- align with required default-deny workflow baseline; previously granted `contents: read` to the whole workflow -- [3] |
| 2 | `brand-plugin-test-playwright.yml` :: `setup`: BEFORE `contents: read` -> AFTER `permissions: {}` -- job only derives a branch name from ref env vars and does not use `actions/checkout` or other token-backed GitHub API calls -- [3] |
| 3 | `auto-translate.yml` :: `translate`: added aligned inline comments for existing `contents: write` / `pull-requests: write`, and moved the `permissions` block to immediately follow `uses:` per the audit’s job layout rule -- [3] |
| 4 | `newfold-prep-release.yml` :: `prep-release`: added aligned inline comments for existing `contents: write` / `pull-requests: write`, and moved the `permissions` block to immediately follow `uses:` per the audit’s job layout rule -- [3] |
| 5 | `unit-tests-and-coverage-report.yml` :: `unit-tests`: added aligned inline comments for existing `contents: write` / `pull-requests: write`, and moved the `permissions` block to immediately follow `uses:` per the audit’s job layout rule -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| unit-tests-and-coverage-report.yml | get-repo-name | `10` | lightweight metadata-only job; short cap prevents a stuck runner without impacting realistic runtime. |
| unit-tests-and-coverage-report.yml | unit-tests | `120` | reusable codecoverage workflow runs a broad PHP matrix plus coverage merge/Pages push steps that can be slow on cold caches. |
| satis-webhook.yml | webhook | `30` | checkout, local grep validation, and a single repository-dispatch call should finish quickly; 30 minutes matches common guardrails for small release hook workflows. |
| lint.yml | phpcs | `30` | Composer install, PHPCS, diff-based changed-files, and occasional auto-commit on `main` are typically well under this cap. |
| brand-plugin-test-playwright.yml | setup | `10` | only computes branch metadata from environment variables. |
| brand-plugin-test-playwright.yml | bluehost | `120` | reusable Playwright + `wp-env` installs can be long-running; needs a higher ceiling than lint-style jobs. |
| brand-plugin-test-playwright.yml | bluehost-dev | `120` | same rationale as `bluehost`, plus an alternate plugin branch may change dependency resolution timing. |
| auto-translate.yml | translate | `120` | reusable translations pipeline may run i18n tooling, optional Azure translation, artifact handoffs, and PR operations. |
| newfold-prep-release.yml | prep-release | `60` | reusable release prep runs Composer/npm installs and may execute build/i18n scripts before branching/PR steps. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Callable workflows in `newfold-labs/workflows` were reviewed at `main` for expected `GITHUB_TOKEN` usage (e.g., `reusable-codecoverage.yml` pushing `gh-pages` and PR comments; `reusable-translations.yml` using `gh pr` and git pushes; `module-plugin-test-playwright.yml` cloning multiple private repos; `reusable-module-prep-release.yml` using `gh pr list`). If those reusables change behavior, re-validate the corresponding caller `permissions` and timeouts. |
| 2 | `satis-webhook.yml` dispatches using `secrets.WEBHOOK_TOKEN` (not `github.token`); job `permissions` only cover `actions/checkout` with the default token. |


